### PR TITLE
add auto apical basal boundary detection to nb 5

### DIFF
--- a/Final/Jupyter_Notebooks/05.filtering_tracks.ipynb
+++ b/Final/Jupyter_Notebooks/05.filtering_tracks.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "d931927b",
    "metadata": {},
    "outputs": [],
@@ -33,12 +33,12 @@
    "id": "d59676f2-b289-4961-a9eb-a3166dbc4922",
    "metadata": {},
    "source": [
-    "### Do not change the code in the cell below "
+    "Do not change the code in the cell below "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "15d231af-e45a-4420-860a-2858a3301462",
    "metadata": {},
    "outputs": [],
@@ -60,11 +60,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "330b03a6",
    "metadata": {},
    "outputs": [],
    "source": [
+    "# open tracks and movie\n",
     "track_df = pd.read_pickle(input_directory_full)\n",
     "\n",
     "z2 = zarr.open(zarr_full_path, mode='r')\n"
@@ -75,42 +76,39 @@
    "id": "e3923861",
    "metadata": {},
    "source": [
-    "This notebook extracts tracks for the following channel combinations\n",
-    "1. Channel 1, Channel 2 and Channel 3 all positive\n",
-    "2. Channel 1 and Channel 3 positive \n",
-    "3. Channel 2 and Channel 3 positive \n",
-    "\n",
-    "To come up with the correct tracks multiple user input are needed. \n",
-    "\n",
-    "Parameters required to update\n",
-    "1. **threshold** in drop_short_tracks():  Tracks with length below and including this threshold value are dopped \n",
-    "2. **cutoff** in drop_early_peak_tracks(): This looks at the frame on which peak value of the amplitude/intensity of a track for a specific channel is reached. If cutoff is 3, the track which have peak for a specific channel below or at the third frame will not be considered as positive for that channel. This step is done for all the channels. \n",
-    "3. **threshold** in drop_tracks_below_intensity(): This is the minimum intensity value that a specific channel within a track must achieve to be considered positive for that channel. You can link this to spot_intensity from notebook 01. Where anything below spot_intensity is considered as noise, likewise for threshold if a spot does not reach a specific intensity for a specific channel it means that the track is not positive in that channel and its only noise. This step is done for the two channels apart from the one on which detection is performed. For example in this case detection is performed on channel 3 so **drop_tracks_below_intensity()** needs to be perfomed on channel 1 and channel 2. The threshold value for both channels will be different and can be decided through visualisation in Napari. \n",
-    "\n",
-    "\n",
-    "Lastly, this notebook allows you to set assign membrane region to the tracks (apical,basal,lateral), if your cell has any. If you cell does not then it will assign all tracks to basal region and you can ignore this column in the next steps. "
+    "## Set filtering parameters below"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "6c6e9526",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Setup the parameters in this step \n",
+    "# Drop tracks shorter than this length (in frames)\n",
+    "threshold_length = 3 \n",
     "\n",
-    "threshold_length = 3 # this is the first threshold explained above \n",
-    "peak_cutoff = 3 # this is the second parameter explained above \n",
-    "threshold_intensity_channel_1 = 240 # this is the the third parameter explained above \n",
-    "threshold_intensity_channel_2 = 150 # this is the the third parameter explained above \n",
+    "# Drop tracks in which the peak intensity happens at or before this frame\n",
+    "peak_cutoff = 3 \n",
     "\n",
-    "membrane_regions_exist = True # set this to false if no membrane regions exist \n"
+    "# This is the minimum intensity value that a specific channel within a track must achieve to be considered positive for that channel.\n",
+    "threshold_intensity_channel_1 = 240 \n",
+    "threshold_intensity_channel_2 = 150 \n",
+    "\n",
+    " # set this to false if you don't want to classify by apical, lateral, basal\n",
+    "membrane_regions_exist = True\n",
+    "\n",
+    "# set default channel names (optionally adjust)\n",
+    "\n",
+    "channel1_name = 'channel 1'\n",
+    "channel2_name = 'channel 2'\n",
+    "channel3_name = 'channel 3'\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "0e353817",
    "metadata": {},
    "outputs": [],
@@ -121,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "c4bb771a",
    "metadata": {},
    "outputs": [],
@@ -159,12 +157,12 @@
    "id": "6dc53d8a",
    "metadata": {},
    "source": [
-    "Filter out tracks based on criteria"
+    "Filter out tracks based on length and completeness"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "25b6d86f",
    "metadata": {},
    "outputs": [],
@@ -182,12 +180,13 @@
    "id": "45094290",
    "metadata": {},
    "source": [
-    "Determining Valid Channel 3 tracks "
+    "### Determining Valid Channel 3 tracks \n",
+    "valid_c3_tracks will serve as baseline \"clathrin positive\" and valid tracks"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "1169ea32",
    "metadata": {},
    "outputs": [],
@@ -203,37 +202,19 @@
   },
   {
    "cell_type": "markdown",
-   "id": "02b1b4fd",
-   "metadata": {},
-   "source": [
-    "**valid_c3_tracks will serve as baseline \"clathrin positive\" and valid tracks**"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "21b05eef",
    "metadata": {},
    "source": [
-    "Filtering for Channel 2 "
+    "### Filtering for Channel 2 \n",
+    "dnm2_positive_tracks will serve as the baseline for dynamin positive tracks"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "fb9e7696",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(475, 21)"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Channel 2-positive tracks\n",
     "\n",
@@ -253,20 +234,20 @@
   },
   {
    "cell_type": "markdown",
-   "id": "188cbf7d",
+   "id": "237f65b1",
    "metadata": {},
    "source": [
-    "**dnm2_positive_tracks will serve as the baseline for dynamin positive tracks**"
+    "### Identifying Channel 1 positive tracks "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "30ace9e8",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Identifying Channel 1 (Actin) positive tracks \n",
+    "\n",
     "### Identifying Actin Positive Tracks \n",
     "actin_positive_tracks = drop_tracks_below_intensity(df = valid_c3_tracks, threshold = threshold_intensity_channel_1, \n",
     "                                          intensity_peak_frame = 'c1_peak' )\n",
@@ -289,7 +270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "1e42300b",
    "metadata": {},
    "outputs": [],
@@ -301,20 +282,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "73c6d973",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "number of actin positive tracks are: 1492\n",
-      "number of dynamin positive tracks are: 475\n",
-      "number of dynamin and actin positive tracks are: 365\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# ***Setting actin positive tracks to True***\n",
     "\n",
@@ -325,7 +296,7 @@
     "final_tracks.loc[final_tracks['track_id'].isin(actin_positive_track_ids), 'channel1_positive'] = True\n",
     "\n",
     "actin_rows_count = final_tracks[final_tracks['channel1_positive'] == True].shape[0]\n",
-    "print(f'number of actin positive tracks are: {actin_rows_count}')\n",
+    "print(f'number of {channel1_name} positive tracks are: {actin_rows_count}')\n",
     "\n",
     "# ***Setting dynamin positive tracks to True***\n",
     "\n",
@@ -336,11 +307,12 @@
     "final_tracks.loc[final_tracks['track_id'].isin(dnm2_positive_track_ids), 'channel2_positive'] = True\n",
     "\n",
     "dnm2_rows_count = final_tracks[final_tracks['channel2_positive'] == True].shape[0]\n",
-    "print(f'number of dynamin positive tracks are: {dnm2_rows_count}')\n",
+    "print(f'number of {channel2_name} positive tracks are: {dnm2_rows_count}')\n",
+    "\n",
     "\n",
     "actin_dnm2_rows_count = final_tracks[(final_tracks['channel2_positive'] == True) & \n",
     "                                     (final_tracks['channel1_positive'] == True)].shape[0]\n",
-    "print(f'number of dynamin and actin positive tracks are: {actin_dnm2_rows_count}')"
+    "print(f\"number of {channel1_name} and {channel2_name} positive tracks are: {actin_dnm2_rows_count}\")"
    ]
   },
   {
@@ -348,31 +320,32 @@
    "id": "b6c6ab8d",
    "metadata": {},
    "source": [
-    "# Allocating Apical/Basal/Lateral boundaries to tracks\n",
-    "Using channel 1 (actin) for this purpose "
+    "### Estimating Apical/Basal/Lateral boundaries of cell\n",
+    "Based on the slices with the most intensity in channel 1"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
+   "id": "4168dfc0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import importlib\n",
+    "import filters\n",
+    "importlib.reload(filters)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "4a730eb0",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmcAAAHHCAYAAAD6Rv9iAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/H5lhTAAAACXBIWXMAAA9hAAAPYQGoP6dpAACl0UlEQVR4nOzdd3hT1RvA8W+SpnvS0kFp2UM2lFWmzDJEGQoiKgiIbBEFxQUOQERFQEBxAE4QFX8iCLKRDWXInoWySlndOzm/Pw4NVGa1JaW8n+e5D8295977Ji3JmzMNSimFEEIIIYQoEIz2DkAIIYQQQlwlyZkQQgghRAEiyZkQQgghRAEiyZkQQgghRAEiyZkQQgghRAEiyZkQQgghRAEiyZkQQgghRAEiyZkQQgghRAEiyZkQQgghRAEiyZkQ4j/r1asXJUuWzLfrz549G4PBwPHjx/PtHsI+DAYDY8aMsT2W37UQkpwJIW4h+4Mye3N2dqZ8+fIMHjyYc+fO2Ts8kY+u/b3fbLs2qRJC5B0HewcghCj43n77bUqVKkVaWhrr1q1jxowZLF68mD179uDq6srnn3+O1Wq1d5giD33zzTc3PTZmzBiOHj1KvXr18vy+Tz31FI8//jhOTk55fm0h7hWSnAkhbqtt27bUrl0bgL59++Lr68tHH33E//73P7p3747ZbLZzhOLfSE5Oxs3N7YbHnnzyyRvu/+KLLzh69ChDhgyhbdu2eR6TyWTCZDLl+XWFuJdIs6YQIteaN28OQFRUFHB9n7PRo0djNBpZsWJFjvP69euHo6Mju3btsu3bvHkzbdq0wcvLC1dXV5o2bcr69ev/VVwxMTE888wzFC9eHCcnJ4KCgnjkkUdy9F+6WXNcyZIl6dWrl+1xdpPuunXrGDp0KEWLFsXb25vnnnuOjIwM4uLiePrpp/Hx8cHHx4eRI0eilLqjOKdPn07lypVxcnKiWLFiDBo0iLi4ONvxwYMH4+7uTkpKynXndu/encDAQCwWi23fH3/8QePGjXFzc8PDw4P27duzd+/eHOf16tULd3d3jh49Srt27fDw8KBHjx53FG+2vXv3MnToUGrWrMnEiRNvW37btm1ERETg5+eHi4sLpUqVonfv3rc852Z9zv744w+aNm2Kh4cHnp6e1KlTh++//z5HmTv5W0pMTGTYsGGULFkSJycn/P39adWqFdu3b7+zF0GIu0CSMyFErh09ehQAX1/fGx5//fXXqVGjBn369CExMRGApUuX8vnnn/Pmm29SvXp1AFauXEmTJk1ISEhg9OjRjBs3jri4OJo3b86WLVtyHVeXLl1YsGABzzzzDNOnT2fo0KEkJiYSHR39L58pDBkyhMOHD/PWW2/x8MMPM3PmTN544w06dOiAxWJh3LhxNGrUiIkTJ96yKTDbmDFjGDRoEMWKFePDDz+kS5cufPbZZ7Ru3ZrMzEwAunXrRnJyMosWLcpxbkpKCgsXLuTRRx+11S598803tG/fHnd3dyZMmMAbb7zBvn37aNSo0XUJTlZWFhEREfj7+/PBBx/QpUuXO34dUlJS6Nq1KyaTiblz59622TE2NpbWrVtz/PhxXnnlFaZOnUqPHj3YtGnTHd8z2+zZs2nfvj2XLl1i1KhRvPfee9SoUYMlS5bYytzp31L//v2ZMWMGXbp0Yfr06bz00ku4uLiwf//+XMclRL5RQghxE7NmzVKAWr58uTp//rw6efKkmjt3rvL19VUuLi7q1KlTSimlevbsqUqUKJHj3N27dytHR0fVt29fdfnyZRUcHKxq166tMjMzlVJKWa1WVa5cORUREaGsVqvtvJSUFFWqVCnVqlWr6+KIioq6aayXL19WgJo4ceItnxOgRo8efd3+EiVKqJ49e153z3/GFx4ergwGg+rfv79tX1ZWlipevLhq2rTpLe8dGxurHB0dVevWrZXFYrHt/+STTxSgvvrqK6WUfm2Cg4NVly5dcpz/448/KkCtXbtWKaVUYmKi8vb2Vs8++2yOcjExMcrLyyvH/p49eypAvfLKK7eM8WZ69+6tADVnzpw7Kr9gwQIFqK1bt96y3D9/H//8XcfFxSkPDw9Vr149lZqamuPc7N9Lbv6WvLy81KBBg+7oOQhhL1JzJoS4rZYtW1K0aFFCQkJ4/PHHcXd3Z8GCBQQHB9/0nCpVqvDWW2/xxRdfEBERwYULF5gzZw4ODrqr686dOzl8+DBPPPEEFy9e5MKFC1y4cIHk5GRatGjB2rVrczXIwMXFBUdHR1avXs3ly5f/83PO1qdPHwwGg+1xvXr1UErRp08f2z6TyUTt2rU5duzYLa+1fPlyMjIyGDZsGEbj1bffZ599Fk9PT1tNmcFg4LHHHmPx4sUkJSXZys2bN4/g4GAaNWoEwLJly4iLi6N79+621+/ChQuYTCbq1avHqlWrrothwIABuX4Nvv/+e7766iueeuopnn766Ts6x9vbG4Dff//dViP4byxbtozExEReeeUVnJ2dcxzL/r3k5m/J29ubzZs3c+bMmX8dkxD5TQYECCFua9q0aZQvXx4HBwcCAgKoUKFCjuTiZkaMGMHcuXPZsmUL48aNo1KlSrZjhw8fBqBnz543PT8+Ph4fH587itHJyYkJEybw4osvEhAQQP369XnooYd4+umnCQwMvKNr3EhoaGiOx15eXgCEhIRct/92SeGJEycAqFChQo79jo6OlC5d2nYcdNPmxx9/zG+//cYTTzxBUlISixcv5rnnnrMlJdmvYXYfwH/y9PTM8djBwYHixYvfMsZ/Onz4MP3796d8+fJMnz79js9r2rQpXbp04a233mLSpEk8+OCDdOzYkSeeeCJXIzGzm9CrVKlyyxjhzv6W3n//fXr27ElISAhhYWG0a9eOp59+mtKlS99xTELkN0nOhBC3VbduXdtozdw4duyY7YNz9+7dOY5l12RMnDiRGjVq3PB8d3f3XN1v2LBhdOjQgV9//ZWlS5fyxhtvMH78eFauXEnNmjVvee61HeyvdbORgzfar+5wQMCdqF+/PiVLluTHH3/kiSeeYOHChaSmptKtWzdbmezX8JtvvrlhAppdS5nNycnpjpLqbOnp6XTr1o2MjAzmzp2bq9+HwWDgp59+YtOmTSxcuJClS5fSu3dvPvzwQzZt2pTr3+2t5OZvqWvXrjRu3JgFCxbw559/MnHiRCZMmMAvv/ySL6NPhfg3JDkTQuQLq9VKr1698PT0ZNiwYYwbN45HH32Uzp07A1CmTBlA1+60bNkyz+5bpkwZXnzxRV588UUOHz5MjRo1+PDDD/n2228B8PHxyTEyEiAjI4OzZ8/mWQw3U6JECQAOHjyYo6YmIyODqKio616Hrl27MnnyZBISEpg3bx4lS5akfv36tuPZr6G/v3+evobZXnrpJXbs2MHkyZNvm9zeTP369alfvz5jx47l+++/p0ePHsydO5e+ffve0fnZz3HPnj2ULVv2lmXu9G8pKCiIgQMHMnDgQGJjY6lVqxZjx46V5EwUGNLnTAiRLz766CM2bNjAzJkzeeedd2jQoAEDBgzgwoULAISFhVGmTBk++OCDHP2qsp0/fz5X90tJSSEtLS3HvjJlyuDh4UF6enqOfWvXrs1RbubMmTetOctLLVu2xNHRkSlTpuSoZfvyyy+Jj4+nffv2Ocp369aN9PR05syZw5IlS+jatWuO4xEREXh6ejJu3Lgb9uvK7Wt4rQULFvDJJ5/w8MMPM3To0Fyff/ny5etqErNrta79fdxO69at8fDwYPz48df9frOvf6d/SxaLhfj4+BzH/P39KVasWK5iEiK/Sc2ZECLP7d+/nzfeeINevXrRoUMHQE+HUKNGDQYOHMiPP/6I0Wjkiy++oG3btlSuXJlnnnmG4OBgTp8+zapVq/D09GThwoV3fM9Dhw7RokULunbtSqVKlXBwcGDBggWcO3eOxx9/3Faub9++9O/fny5dutCqVSt27drF0qVL8fPzy/PX4Z+KFi3KqFGjeOutt2jTpg0PP/wwBw8eZPr06dSpU+e6iV9r1apF2bJlee2112xNjNfy9PRkxowZPPXUU9SqVYvHH3+cokWLEh0dzaJFi2jYsCGffPJJruM8e/Ysffr0wWQy0aJFC1ut4z+VKVOG8PDwGx6bM2cO06dPp1OnTpQpU4bExEQ+//xzPD09adeu3R3H4unpyaRJk+jbty916tThiSeewMfHh127dpGSksKcOXPu+G8pMTGR4sWL8+ijj1K9enXc3d1Zvnw5W7du5cMPP8z16yREvrHrWFEhRIGWPa3B7aZDuHYqjaysLFWnTh1VvHhxFRcXl6Pc5MmTFaDmzZtn27djxw7VuXNn5evrq5ycnFSJEiVU165d1YoVK66L41ZTaVy4cEENGjRIVaxYUbm5uSkvLy9Vr1499eOPP+YoZ7FY1Msvv6z8/PyUq6urioiIUEeOHLnpVBr/fO6jR49WgDp//vx1r4Gbm9stX6dsn3zyiapYsaIym80qICBADRgwQF2+fPmGZV977TUFqLJly970eqtWrVIRERHKy8tLOTs7qzJlyqhevXqpbdu2/av4Vq1apYDbbte+Xv+0fft21b17dxUaGqqcnJyUv7+/euihh3LEpNTtp9LI9ttvv6kGDRooFxcX5enpqerWrat++OGHHGVu97eUnp6uRowYoapXr648PDyUm5ubql69upo+ffodvS5C3C0GpfKwB6sQQgghhPhPpM+ZEEIIIUQBIsmZEEIIIUQBIsmZEEIIIUQBIsmZEEIIIUQBIsmZEEIIIUQBIsmZEEIIIUQBIpPQ3mOsVitnzpzBw8PDtvixEEIIIQo2pRSJiYkUK1bstmvcSnJ2jzlz5gwhISH2DkMIIYQQ/8LJkycpXrz4LctIcnaP8fDwAPQv19PT087RCCGEEOJOJCQkEBISYvscvxVJzu4x2U2Znp6ekpwJIYQQ95g76ZIkAwKEEEIIIQoQSc6EEEIIIQoQSc6EEEIIIQoQSc6EEEIIIQoQSc6EEEIIIQoQSc6EEEIIIQoQSc6EEEIIIQoQSc6EEEIIIQoQSc6EEEIIIQoQSc6EEEIIIQoQSc6EEEIIIQoQSc6EEEIIIQoQSc6EEEKI/8pqhbQ0e0chCglJzoQQQoj/4uJFqFsX/P1h7lx7RyMKAUnOhBBCiH8rLg4iIiAyEhIToXt3GD4cMjPtHZm4h0lyJoQQQvwbSUnQrp1OzPz8YOBAvX/SJGjVCs6ds2984p4lyZkQQgiRWykp0KEDbNwIPj6wfDlMmwa//AIeHrBmDVSpAq+9BidO5DxXKb0vIcE+sYsCT5IzIYQQIjdWrYLGjWH1avD0hKVL2VAkme/+/g7VsSNs2QKVKsGFCzBuHJQurRO5N9/UNW1Fi0LJkhAUBF9+qZM1Ia5hUEr+Ku4lCQkJeHl5ER8fj6enp73DEUKI+8f27TBqFPz5p37s6YlatIgPDBt5efnLKBRD6g5hcpvJGLKy4H//gxkzYOXK669lMFxNyh59FGbO1DVwotDKzee31JwJIYQQt5KVBYMGQViYTszMZhg8mLR9f9Pz/ExGLh+JQidaU7dMZeSykSgHB510rVgBBw7AiBHQqxdMnQqbN0NyMkyYAA4O8NNPUL06rFtn3+cpCgypObvHSM2ZEELcRUlJ0LUr/PGHfvzEE/DOO5zyc+Sx+Y+x6dQmTAYTH7f5GEeTI8/9/hwArzV+jXebv3v762/dqq955Ag4O8POnVChQv49H2E3ufn8drhLMQkhhBD3lpgYaN9eN2e6uBD99VQWFE/il7XPsC56HVZlxdvZm/mPzadl6ZYApGelM3TJUMb+NRYDBl5v8jpODk43v0edOrBjBzz8sO7L1rOnrkFzkI/n+5k0awohhBD/tGMHhIfD9u3EhvrS5aN6lNjbl2FLh7H2xFqsykqDkAZs6bsFv4SWPPQQ1K8PXUKGMLHVRADe/etdSnxcgjGrxxCTFHPze7m7w5w54OWlmzwnTrxLT1IUVNKseY+RZk0hhMhH69bBe+/BokUA/PZgEM+2ySA27SIGDDQu0ZhOFTvRqWInTEkleP11+Prrq337GzTQFWCzd8/k7TVvczrxNABmo5nwkHCMBiNWZcWqrNQOqs24FuNwMbvok7/+Wtecmc2wbRtUq2aPV0Dkk9x8fktydo+R5EwIIfLBrl16EtkNG1DAGU8Y80xpvvA5BkAln5q8WekHrOcrcOAA7N8PCxdeXU7zscf0WIH4eBg6FCZPhkxLJgsOLGDy5slsOLnhhrdtENKA3x7/DV9XX53hdeqkR3lWr66n5HB0vEsvgMhvkpwVYpKcCSFEHktO5kztCkwNPs32YAM7gj05n+IDFypCdGOKx3XjwuHSpKUZrju1aVPdClmnjk7WHn5Y7//uO93PP9vOmJ3sP78fo8GI0WAkPj2eEctGEJcWRwXfCix5cgklvUvqVQUqV9brdb7yCowff3deA5HvJDkrxCQ5E0KIvJX+6kjK/r2XUztGQ3wJSA64YTkfHz237AMPQMWKOiFr3FhPWZbtjTfg3XfBxQU2bbp1y+Te2L20/a4tJxNOEugeyOInFlMzqKaeWuOxx3ShIUPgww91U6e4p0lyVohJciaEEHlo/36ef6YzUyIjIcvVttvJSVGypIHwcGjUSG/ly+dMxGwyLsPBqZBxCUuV8bR72IU//4QSJfS0Zg89dJPzgNMJp2n3fTv+Pvc3Ps4+7B24lyCPIBg7Fl5/XRdq3hx+/BF8ffP++Yu7RpKzQkySMyGEyCNKsbdtQ6r+PRl1tg6V68bw7WeBFC+u86CbJVQ2GXFw4GM4OAkyr6yTGdqVixV/oE5dI1FRelfduro2rWXLG18zPi2eZnOasSNmB10e6MJPXX/SBxYsgKee0hPWlioFs2frEQcyzcY9SZKzQkySMyGEyBvq228pNTGKE3+/gYNrAscOeBAS8o/sKe0CJOyHhAOQfEInYdnbuVWQGafLeVWCxMNgzYTKr3Ox+DtMnKhrzlJSdJGqVaFmTd00WqmSnnqjaFF9bFfMLmp/Xpssaxa/dP2FTg900gd274ZHHsGW6bm76yk+GjfWIztDQ/P9dRJ5Q5KzQkySMyGEyANxcbze9DHG7l4CysSS2Z8REfAFWFJBZYE1Syde6RdvfR2vylB5DGTVgUtH4FgXsMZD+NdQ6inOndMzc8yYAenpOU91ddXdyZ57TteovbbiNcatG0eQexD7Bu3D29lbF7x4EZ5/Xk/vERd39QIBAbBnD/j55d3rIvKNJGeFmCRnQgjxH2VkENWtB2VXTcAaX5qBvT5lWuvBoCw3Lu9WAjwrgnsZcPQGs6fe3EqCUzgcjob0DF3WdBFOdgSDFZqvAP9GgB6EuWED7Nunt8hIOHhQnxIRAV9+Cb4BaVT/tDqHLh7i2VrPMrPDzJxxWK06GfvrL/j4Y73k06OP6v5ot22DFfYmyVkhJsmZEEL8BykpXOj0BA/s7s+Fs22oWnElO9/qhDErAUo8AWX7gsEBDCZwcAOPsvrfa1mtkJ4JJ8/C2Qt6n7MjZFn0xjE43QMcXKDC81BhCDj7X3eJqVP1bBlpaeDtDTNnQkDdtTSd3RSAVT1X8WDJB2/8PCIjdbtoVhb88AM8/nievkwi70lyVohJciaEEP9SQgLHInpS8+CbJFyuia9PNMemNcJTnYSijaD5cjD9Yx1MpSA+EWIvQXwSZGReScCuEewPpYIhKRX+PqQzL8s2iBkIKDA5Q+lnoMyz4Fk+R7J34AA8/bRe/9xk0v/OPD2ATyM/JdgjmF+6/ULd4Lo3fj5vvQVjxug5PvbuhaCgPH25RN7Kzee3XdfWHDNmDAaDIcdWsWJF2/G0tDQGDRqEr68v7u7udOnShXPnzuW4RnR0NO3bt8fV1RV/f39GjBhBVlZWjjKrV6+mVq1aODk5UbZsWWbPnn1dLNOmTaNkyZI4OztTr149tmzZkuP43YxFCCFEHjt/nm0NnqXy31NIuFwTs+dJdk3vqBMzt1LQ+BedmFkskJQCFy7D0ZOw6W/YdUjXkKWkXU3MDAZwd4XqFaBsqM6svNyhUhl9zFQbKq6AIo3BkgaHZ8CSWvCjO/zsD0vrQeQLVCwRw4YN0LmzvnXfvjC22QQq+FbgdOJpGn3ViCmbp3DDepRXX4VateDyZXj22atrSIl7nt0XPq9cuTJnz561bevWrbMde+GFF1i4cCHz589nzZo1nDlzhs6dO9uOWywW2rdvT0ZGBhs2bGDOnDnMnj2bN99801YmKiqK9u3b06xZM3bu3MmwYcPo27cvS5cutZWZN28ew4cPZ/To0Wzfvp3q1asTERFBbGzsXY9FCCFEHvvrL+Y/8DLhBz8nLSUE/1LriPrqMYKtO3TfsQd/h0vAxl2wbgdE7oO9R+HUOV1TZjJBoB9UKQu1K0ODGtC4FoRVAm+PnPfy9YIKJfXPiR7g/jFUXg/FeoHZGzBDljMkKTgyH34rg8PeN5gxJQEfH9i+HWZ96snmvpvp8kAXMq2ZPL/keR6b/xjxafE572U26/U4HR31YIGPP5YErbBQdjR69GhVvXr1Gx6Li4tTZrNZzZ8/37Zv//79ClAbN25USim1ePFiZTQaVUxMjK3MjBkzlKenp0pPT1dKKTVy5EhVuXLlHNfu1q2bioiIsD2uW7euGjRokO2xxWJRxYoVU+PHj7/rsdxOfHy8AlR8fPwdnyOEEPelrCx1adT76jGHOUpnLUq1avmBSp1bRKnvUOoHJ6VOL1Hq/GWlVm+9uq3brlTkXqX2HVXq/CWlLJbc3/vcRaW27M553fU7cj5etUmp/z2l1HcGpX7yVWtnf6FAKRcXpY4eVcpqtaopm6Yo89tmxRiU4zuOqvFXjdVrK15TSw4vUWmZafpe77+vbE+wdm2l/vxTKas1L19JkQdy8/lt95qzw4cPU6xYMUqXLk2PHj2Ijo4GIDIykszMTFq2bGkrW7FiRUJDQ9m4cSMAGzdupGrVqgQEXF1qIyIigoSEBPbu3Wsrc+01sstkXyMjI4PIyMgcZYxGIy1btrSVuVux3Eh6ejoJCQk5NiGEELdx5gxLwl6jwoQnmJ/1NA4Oabz/UnOWPjMCZ8slPS9Zm63g1QQO6MXNCSqqa8Ua1oRaleCB0uDnA8Z/8VHpX0TXslUrD37eel/mlW4uRqMeQGAwgddQCPgMMrNobO7Liz2Wk5oK/fsDGBhSbwjreq+jvG95MiwZ/BX9F2P/Gkub79rQ8KuGpGamwvDhuv+Zmxts2watW0OLFrBkCWRmXh9bUhKsXKlXaRcFkl2Ts3r16jF79myWLFnCjBkziIqKonHjxiQmJhITE4OjoyPe3t45zgkICCAmJgaAmJiYHMlQ9vHsY7cqk5CQQGpqKhcuXMBisdywzLXXuBux3Mj48ePx8vKybSEhITcsJ4QQAlCK/e/9j8dKbqHtrvc4bw2meOk1bJpWnBE1V2FAQdnnIGIruD0Ae46AxQpeHlA2BMx5OPu+wQA+nlC5LNSvBrUegAbVoVFNqFsVypfQZRxqQtACcKzK+I69Keodz7Jl8O23+jJ1g+tyYNABDg0+xBcdvqBn9Z54OXkReTaSYUuG6WbXN9+EY8dg2DDdzLlqFbRtC8WKwYAB8Oef8Omn0L69nhetRQuoXl0nc6LAsWty1rZtWx577DGqVatGREQEixcvJi4ujh9//NGeYRUoo0aNIj4+3radPHnS3iEJIUSBdGxTLD1KrKDyqIf4KbMjYCWia3/2vt2aMPeLYPaCRj9B3U/B6Az7jkJauq7Fqlz639WQ3SknR/Bw0/3EDAa9BRXVCZuLE+ABftMxW00smzAcgH799CS1FgsYDAbK+ZajT60+zO44m5+6/oQBAzO3z2Tunrn6Hv7+MGkSHD6sF0z394cLF3RSFhGhk7TFi/VsuE5OcOIENGyoZ8iVvmoFit2bNa/l7e1N+fLlOXLkCIGBgWRkZBB37WzIwLlz5wgMDAQgMDDwuhGT2Y9vV8bT0xMXFxf8/PwwmUw3LHPtNe5GLDfi5OSEp6dnjk0IIUROX47eTrkGPnx/siUKEw6VfuTd94rxxyMz8TRkgE8taLsdQrvobGd/FMQlgskIVcrppMke3F11E6q3Bxicocg4qrt/x1v9fictDV56SS+6fuBAztNalm7Jq41fBaDfwn4cuXTk6sHQUJgyBU6fhmXLoE8fCA7Wyz6NH6+n3Th3Djp2hIwMGDhQr+G5ahVs2gS7dulaOKv17r0OIocClZwlJSVx9OhRgoKCCAsLw2w2s2LFCtvxgwcPEh0dTXh4OADh4eHs3r07x6jKZcuW4enpSaVKlWxlrr1Gdpnsazg6OhIWFpajjNVqZcWKFbYydysWIYQQuXf873j6jy+DVZkpV2cWn0wsy+U3+vBayDndjFluALReD+6lITUNdhzQU2UYDFCxNLjd+MvxXeNg0v3bzA5gLgdew3gj4lm++eIinp46X6pRA7p21XOi9e6t+6Q1ynyLRqGNSMxIpNtP3UjP+sf6UA4OerX1L76AU6f0EgWvvKIX9vTygl9+gQ8+0M2i330HzZvrBK5GDShTRi+2/vLLsHOnrllLTISlS+G11+Cxx/R+kT/uwgCFm3rxxRfV6tWrVVRUlFq/fr1q2bKl8vPzU7GxsUoppfr3769CQ0PVypUr1bZt21R4eLgKDw+3nZ+VlaWqVKmiWrdurXbu3KmWLFmiihYtqkaNGmUrc+zYMeXq6qpGjBih9u/fr6ZNm6ZMJpNasmSJrczcuXOVk5OTmj17ttq3b5/q16+f8vb2zjHy8m7FcjsyWvMuWbFCqddfV+qtt5R67z2lJk1S6o8/ZASUEAWMxaJU+eCtqmzAIbXq7Rp6FGb29rO/UlHfXy18IU6PxMweORmXYLe4b+hi3NWRnD83V2pVe3Xq6EXVps3VwZjXbkajUp99fUH5TvBVjEE1/LKheu+v99T66PVXR3LeibVrlXrwQaUqVVKqZEmlAgKUcnLKebNixfQNr93n56fU/v3593oUMrn5/LZrctatWzcVFBSkHB0dVXBwsOrWrZs6cuSI7XhqaqoaOHCg8vHxUa6urqpTp07q7NmzOa5x/Phx1bZtW+Xi4qL8/PzUiy++qDIzM3OUWbVqlapRo4ZydHRUpUuXVrNmzboulqlTp6rQ0FDl6Oio6tatqzZt2pTj+N2M5VYkOctnMTFKde9+43dCUKpnT6VSU+0dpRDiitefXKvMpnS1Y3xVnZB9b1RqVTulon9RypKhC1ksSh07dTXxidynVFq6fQO/maMndYwrVyo1t5hSP/kq66HP1O8Ls9THHys1caJS48cr1bGjfktydFTqna82KeNbRsUYbJvTO07qoe8fUvP2zFOpmVffsw6cP6BGrxqtms1upsauHasysjJuHEdKilLz5yvVpUvORK1UKf0+WLOmfhwSotSJE3fntbnH5ebzW5ZvusfI8k35RCmYNUt38Lh8WXcM7tYNPDx059nERPj1V90Ho3Zt3RwgI2eFsKs9q89RraUXbzwygbe6jEE5+mJos0U3X2ZLToUDUXrWf4AgPz2jf352/v8vrFbYdRASksF6Fi5/AGlrdZ+54o9A6hlIOYVKPcfPG9vS9d0xuLoa+WJ+FGe9f2XdyXX8deIvzqect13Sy8mLhys8zN7ze9l+dnuO29UKqsWcjnOo4l/l5jElJOh1pSpUgOLF9b7z56FxY716e4UKejH2okXz4xUpNGRtzUJMkrM8ZrHopOu9964OKa9ZEz7/HMLCcpZdvlwnbJcu6TehH3+EBx+82xELIYDMDEXpYnvxcbUSObYWZpMFGvwAJa8sAK4UnImFY6fAqnS/rnIl9PxjBV1aOmzff3VetMwjkPAZZOwAY1Ew+YPJB9J38OfB1rQd8wWeXiZWrNCrOSml2Hd+H9/v/p5v/v6GkwlXR/mbDCYae/bE8PfTbHX4kKTghZiNZkY3Hc2DJR8kKSOJpIwk0rLSqOBXgWoB1XA0Od44zpMn9WjPkyf1++WKFbovm7ghSc4KMUnO8khiIsydCxMn6mHnAK6u8Pbb7O/Rmklbp7L3/F7K+JShol9FKvhWoG5wXUIuZelF8LI7wj78sO4cW/eahYmzsuDvv/VixKVK3fWnJkRhl5mSSaewLSw9XJdNb9chrOQuKN5Rr4+ZkQkxFyHmPKRl6BN8PPWSSk43STIKosxMOHlOJ5iWm4yatCbDxSH88XcNHnp3FgoTnTvDiBFQr96VIsrK2hNrWXRoES5xtTj4ayd+/tEZy5UlQv2q7uBC/WchOPKGt3A0OVItoBphQWEUdS2Ku6M7Hk4eBLoH8lD5h3A8fEzXoF24AJUrw2+/QenSN7zW/U6Ss0JMkrN/KTkZfvhBD3vavFkPJc/+0/fxQQ0exPpH6/L+3s9ZeGjhDS/hYHRgcpvJDKjUE8PQoboZNPsarVrp8e7r1+sRUUlJ4OICa9fqZlAhRJ5IPniKVo2i2HihMa92fJuxj41GOfpgaPk3nE6DC3FXC5tMUCoYihXVIzPvRZlZeo3P0+d0kmZ2AEezbv5MTQdrIlwYwJojtWjx+tdYrHoS3SZNdC1aerrezp7VCwYoBd6ulxn5+Hy+W9aUvScrAOBR/U/Mwfsw44pZuWIwGLlc5E+Sii8A5xuvTNOqdCt+6/4bzrv368ltz54FX1/4+Wdo2vSuvUT3CknOCjFJzv4Fi0W/U23YkHN/mTJED3iCuTXNfH/oZ3ad2wWAAQOPlO9MhzJdiEmP4uDFg+yK2WU73qdmH6a1m4bTkSjdHPrtt9i+hmZzcNA1aMWKwZYteo4hIcR/cmn+Chr3cmdfSj3CK65k9WutcDRaod63cLmG7l8G4Omu+5YV9dEJWmGQPedYdl85iwX+PgwJSWCNh/PPkWr24tedPXhjZheOxpS47hJuTkl8+sIUHq/+Pg7WeJTBzG+HX6b72FdJzbg6nYirUzJhpSI5cKYil1OKUr7Gefyr7UI5XyLdkka6JZ19ietJLzeX9g+04pduv+AYc17Pm7Ztm37/mz4dnn32Lrww9w5JzgoxSc7+hUmTUMOHs6eUK8e7tyW6lC/RfmY2XN7Fuuh1tmKOGQE0yngHt+Pd2LDKg+TEdMpVcKZhQwgPVxz2+oxxuwZhVVbqBdfj564/E+wZDFFRMHmyntSxYUOdCIaG6p/37dM1Z2vW6GZTIUSupJy6xK6pa4n8+TjvnWpNTGZ5Xun8JmM6voeDQUFwB/D/GGIv6VqlauX1xK73gywL/H0IEpPBcgkuvQQZewDFmfQ6nE6uRgbeZBp8cDJnUtt7Buasi+DWGTx6QNpWSJhJuoMnc/Z8jNGSQG3/n6jkvQRHUypWZSDyWBh/7GrLn7tbcy4+gPQsJ9IznUhM8yC91Gqs3TrQuXJH5j06D4e0DD0J27x5Or6RI/UX2Hu11jKPSXJWiElylktHj6KqVuHxdmn8WNYbjJngkAYmC6R5QHRjQuJ6YD7ZghP7/KlUbDdPNvqW7uE/EOJ7iouJRYi+GEr0xVAij9clJaw9X5maczntMn6ufoxrPo7eNXtjMt7g2/mxY7rjx4ULesLGuXML7ggxIQoSpVjx8Xaee9eNY5fLopRuqitZNIpvBnejUdmtulxoVygxEY5dmfy7ennwvs/eFzOz4O+DkHSl1lCl6KQrYwdk7IPMw6CS9DGnOuAzCkzXjDRX6ZD4LSR9AyoZcAKHYHAuCymbda3cDaRnOvLS9x8wPTUVa4uX6V6lO990+gaTwQjvvqvX+gQ9a+4XX9hvBYYCRJKzQkySs1ywWqFlSyamrWJk6lew8xnbIaPJgrIaMRos1C2zhdZV/6RL3Z+pGrLnlpdctrsl8y/PYlPVR9h9QQ9JrxZQjUkRk2heqjnxafHsjt3Nntg9lPIuRcRZV73AcGam7qU7bpyu8hdCXM9qJet/i3jhhbN8cqIvTuYMwkpF0qDyUhpUXkbLMtvxcMxAOXhgqDMNfDvBzoO6I1WpYAgNsvczsI/MTDh0Ai4l3GTJpcQrWzH90MEEIYFwMV43i8KVJMwCxn+MZnVKhIwNcOkHyEoFgzsYvPVSU6lr6Drla34OWYi1yrcMrD2QT9p9gsFggNmzoW9f3fwaEQE//QTu7vn1CtwTJDkrxCQ5y4XPPmP92P40rjSU2od70L/Fp5iMFjItZrKsDvh7xtKyyko8Xa75Zmh0hKD2ENgbnB4AQxJYz6FSDpC541UcjclERtVi7PrfqTX0f3y4axRxaXEABLoHEpMUkyOERU8sot36WHjmSmJYvbpe865Jk7v0Ighxjzhxgui2z9Li5OscSWrM4NafML77CNwd/7EkUdGGEP4NOBbX002kZ4CvN1QuI81nVquuQYtPhPgkPbdbekbOMsH+UKKYbgJWCi7G6elGUq95nU0mfTztH6/9P6VtJD3mZdp8sJjV4SMgeBsftv6Q4eF64XYWL9atBikpUKcO/PkneHvn5TO+p0hyVohJcnaHTp7kfO0HqNQ0DL8Nn7D5rYZ4uiTeuKxjEQhsCYFtwLM1nE68+m0yRznIPPsW5rTfOXquND2+XErNZsFcKDWNXxJfwYoeFBDiGYK3sze7Y3fj4+xDZL9ISv2yUtecXb6sr9W9O7z//tUJHYW4n2VmsqnukzTZNx0vJyuz+j/FQzWW6mPO/uDXEIo2AL8G4FcfElJg/zGdeDg7QdgDUiN9M5lZeqBEahp4uYPrDdYRtVp1MmcygouzrlkzGPQ55y/rdUgTU/Q+xyujRZPT9HnJv3Pp1BTaTP2Tra0fxuAZw/zH5tOlUhd97c2b9UjOixf1up7jx9/d51+ASHJWiElydgeUwtK+Hc1cdrP7rxVsfrkD5YMOo/zCMRTvCCoLrFlgcoGAB8G7JlxOhOgY3bEW9JuQj6duLkjN0CMvr7Cmb8F4+W3iEtKYtmwQnywbjINnUarVu0iwrxfeHs6YnbJYkDaU/e4zqBlYk/W91+MSnwyvvw4zZ+pvrG5u8PbbMHSofLCI+1r6iFcJ+LwrdUNjmTOwB0GeF1BGJww1P4Dyg67WiCkFJ2Mg6rR+7OIElcvaf+Hy+4HFovvMZv8uLsbBniP654QvOX7sD9p+/isH2rfA2TOFVT1XUb94fX3811+hUyc9Qe3Jk3rllfuQJGeFmCRnd+Crr3hj9gDGRa1i0RNv06b6UqwuoRjbbgPna5YXycyCmAt6ksfsySqNBggqqvtjXDthZWaW/lA4dQ6UQqk0DAkzIelH0jMV363vwY+bu5Ke5YTVasSqjOw+WRXrY4NJLPUdvWv05stHvtTX2rEDBg++OrVHtWowYwY0aHB3Xh8hCpI//6Rdz634lC7Jd4Oe1Pu8KunZ/n2q6YQsPUPX3Jw9D5evzLnlX0TP+O9QSKbKuBedPa/7ugFcHse6HbF0+uFTLnRpgF8RJ9b3Xk953/K6hu2BB+DQIfjoI3jhBfvGbSeSnBVikpzdRnQ0v3eoSAfjNCY8sJ+RD03EanTB2HI9ZBTXfSjSM3QylpRytfOsg0knZcUDdJX9zSSn6jej7GZPFQfxn0Hy/4DMHEUvJ3vT5sMVbG3dA+V7gBntZ9C/dn990GrVk9iOHKmXgwI99UZIiJ4brVgxePRRKHH9XEVCFBoxMXxbvyefuYxi+SsROJkzoPQzEPYJJGbCmfP6/1rm1ZprjAa9Nmagn/QxKwiOn4YTZ1HKguHyW3zyv9KM2vAMSY81ppivDyufXkkFvwp6Sbx+/fR73NGj9+XoTUnOCjFJzm5BKY480pgql1vQlTJ8PaCn3h8+Dy5WvjpB5bXcXaBYgP4WbrrDaS6UgnMX4fiZazrbJkDGRjC4gsEDpVwxpO/i1PF5tP/sN/5u3wicE3mo/ENMaDmBSkUr6dMuXICXX4avvrr+PkWK6GWiZIF1URhlZHC+XScePPE8a1/qjq/HJVTxzhgqfZGziwHoJMzNBTzcdId2acYsOJTSX1hjLujHCZ/Rc2IjfrlUmqROLQjy9mNlz5VUdC8JJUvq+SC/+QaefNKeUduFJGeFmCRnN5f02VQqzoukXlIH5g3phoPJApVeAbf++hu42UEnYU6OenN11m/y//bbt9UKZy9A9Fm9nt+NpCzl710/0nPpp/zdtAlWQxZGg5G+NfvyVrO3CHQP1OX27oXdu+HMGb0EysKFcPCgXhJq1SrpkyYKD6Xgxx/h1Vdp4NSP2X2+pHzQYdI8m+McNOXqfF3ZXQz8i4Cb651/eRJ3n1K6H+BJPVrdkrSEhsPacCT4EBeb9SDQPZCVT6/kgc8X6LWIq1XTXzzvs5pPSc4KMUnObkwdP06zXgNwT3yOBc8/htkhC0r3gjIfwL4oXahqOSjilfc3t1jh3AVISdNNomYzKCsciQYFJH7N8g37+CX1G87WHcKvh34GwNPJk/EtxtO/dn+Mhn988Bw9CjVr6gXaX3tNT+ooxL3MaoXVq0l9eQyf7gthsm93vu71Pk0q/kW8CsbrgT8gMV13Oi92pd/nrboYiILnTCwcOg4GI2lJe6nybARZD0/gRNDHBLgFsOmxpZSs3FCvdbx0KbRube+I76rcfH7LVxFx77NYGDFoEI4J/fh5aDfMDlmo0Meh2nQ4FK3LhATmT2IG+ht9MX/dDyY0SK/pV8wfKpTSxz2epmU9X5qrIcRPncakcn9Tp1gdEtITGLR4EA2/asjuc7tzXrNMGT2rNuiJa5cty5/YhchPFy7At9+S+URPVvp04blW+ymy838sKvUMa14aRJOKf5Gc5YZXnUU6MTMZIawSlAmRxOxeVMwfKhUHlYKze2W2z1iGadHrVHRow7nkc7y3e4aemBZg4kT7xlrASc3ZPUZqzq43//nXmLq2NkuG9sDVKRVLsU6YGs2F3UchIVn3U6lRwT5LJ504C8dPo5QVw6VXSYrbxAeLXuLvjOFU6rGIKVHPkZiRiIPRgQ7lO1DapzQlvEoQ6hVKi9ItcB/6Enz2Gfj7w65dEBh495+DEP/GokUs7vI5n1u7sMzanmRLEdydE3m/+0gGtPwUgFRzMC71foLjZt00VqGk7ugv7m0x+1AHLmIwuHD21F90mNyNyDYlcHEyc/LRDfhWrq2n5oiMhFq17B3tXSPNmoWYJGc57Z2/ksdeU6x76TGKuF8mo2h7HJv/AsfP6WkvTCb9TdzFyT4BKgWHo/WQc4CUPyFhGrGXMnn31zeI9XuSuPqvsfTSjOtOLe1Tms09VuPXrL3uj1a2LIweDY8/Ln3QRME2bx7De+9lrmN/wsttpFro31QtuY0GFdYR6KanwlDlBmCo+h78fULPTl/UBx4ofd/1Qyq0ju9AHc/EYDBycN+vtPqtBCfr92Nc83GM+nQPfP89dO16dZH0+4AkZ4WYJGdXXTgaR+2me1k+vCdlA4+S6lEHl7Zr4HzS1bl3KpWGokVufaH8ppTuf3bm/JWHmRiS5kHiV0Sd8+WdX8cQV7wFPlV3cCo2mbOx6Rw7e5Hk4r/RrJmRpXUmY27eSo9yAihXDt54Q68yIEmaKGi+/JIRg6I4UKkePz3/qJ4e4xpWtxIY630FAc2ujvJzMkNYZT1oRxQeBzbDOROoLDZu+oEmh7bjX+UYx5v/hrlmbd2aceCAfk+7D0ifM1HoJSUqwhsf5Zver1A28CgppiBcWv2u50Y6fKWfWYkg+ydmoGsCypXQNXjeHhgMZvB4EhX4O6XKdeKrAa/yTrUI3FZFYVnqx8VFLUle8QJ8u5RVa9N48cTncPiw7nvm66t/fvppPanjrFl6FQMh7E0p+OgjXh4YxY6yD9oSs0z38lC6N9SaBM2XY2y7D1RVvS5m9vQLFUtLYlYYVagLnplgcCC8Xkded2nImcQzzDcd1Es6Wa3S9+wmpObsHiM1Z3oN3cbVDzO89Rh6NPyeVKszLh0iwaEU7Dig+zL4F4GKpQpeE4lScCkBok7Z5l1TyoIhbRWkrgVrPFjjSEm3MOX3joxa+AI8W58vnn6dPrX66NGb06bBBx/otepAzx30yivQpg0EBICzs/2en7g/HTyIGjiI19bWZ23pNix9OQI35xRSAtrg2vhXSM2ElFQ9y3/sJf1/FPR0GaWCobj0pSy0rFYy/1qNGU8un19Pkb8+pnYVP7ZU/AhDkybg6AhRUXri7UJOmjULsfs9OUtNhSb1DvJM2GQGtpqBRRkwNl+KwfdB2LFfz/zv6Q7Vy9tnAMCdUkovQ3Pq3NXlaP4pfQcvTU3nw83NcHi2KX/2nU+zUs30saQk+PRTnaRlN3dm8/SEoCC90HqfPvn7PMT9LSUFxo0jbsJndDdO40LxUqx4tQWeLomkFn0UF+/ReoqZf3J20tNlBPpJjdn94FIM7D4FKovHv/6NeSXGs773eho88TKsWwcvvXRf1KBJs6YolNLSoGXzrbz30EAGttId6DPDpmAo2gx2H9aJmbMTVClTsBMz0DV6RbygWnnd3FmsKHh7gLur7n+DFZxq8v4gK82KXiBr3rc0n9WK9t+3Z+2JtSg3N/2GFhUFkydD+fL6GyhAQoKewLZvX5g0ya5PUxRSVit8+y1UqsTK91ZQ0XUt1VpHsXxUSzxdEkkp0hEXt1evJmaOZvDxhOAAPd9g3Sp6ehtJzO4PRQJJTT8BBgfeaVIWMlyYtGmSrvEH/UXz8mX7xljASM3ZPeZ+rTlLS1N0eXghk9sM153/s0w4NPoOc4lH4e/Dev09swPUqKhn/r/XxSfBzt2AmdS4PynX+ylOF1sP7QeASxzhxcN5ueHLdKjQ4eoEtkpBfLyuSfvyy6vfRN9/X9eiCZFbP/8Mx45B5cpQpYpeSmzpUnjlFdJ27adfwAu4VS3Omx3HEuSjZ4dP9+2Ck/urkGXVXzaqlNUrcoj7muXENkzH9YCoGrO/Zk/pmRwdcoSSTR/Ro9HfeQdef93eYeYradYsxO7X5GxI/5mMrfMSni6JxCa64vfQcoxB9WDPEd0saDJB9Qrg4WrvUPNO7DnYdwIMRk6f+IMyfUdgck8no3V/sirOBQM84PcAIxqMoEe1HjiarvkAVArGjIG339aPx46FV1+1y9MQ96jvv4cePXLuc3XFmpLKdJduLCjXmRlPv0b5oMMAJJkDcK/yCVwsrVfN8HTTtWQyolhckb7kW5xcKrJxzxEanO/OkHpDmHK5vv478/ODEyfAtRC9h/+DJGeF2P2YnP194DKWBc2oWWIX+0/588ATqyD4Adh3FC7E6SbMauXBy93eoea9qP0QrReAPh61gofe7MjekxUoG76PmMZdSXLdC0CwRzB1guvgZnbDzeyGt7M3z9R8hooz5sObb+prPfoovPAChIcXvIESomDZsgWaNOEzh9ZsLB6Bf1oiQWdO4pqZwQdez9CnzW+MeGgiJqOVy5leuNYaj5M5AmIv6y8G3h66xsxksvczEQVI6ra5uCSXxWrNIHj+28QFr+HE4KP412yku2hMmwYDB9o7zHwjyVkhdj8mZyOeGcPEVm8Rn+qGW9VfcajdHPZHwYXLOsmoWk73Zymsdv8Fl1wAUFnn+GvbIZ6c2JWz8cWo3nIvJ6oM5oL7mutO83H2YWXPldSYvQRGjbp6ICwMhgyBevX0CCkPD0nWxFWnTkGdOkxOr8mwy4ttu53MadQpvZVpvQZRLVQvN3bJvy9FAl+Ei0lXz/fz1lNjyELl4p8yErGs+hmTcxV+jYymU2IXXm30KmP3BcLQoXqi7YMHC36f4X9JkrNC7H5LzpavP0WJzc0oF3iE9Xtq0/DtjbopMz5JJxSVyugPg8JMKTi6E05dAoNeH9SaeZrlG6IY9lkE+888QO0Hz1KhwSE8As/hGnia1Re/Z/u5bfi6+LKq5yqqnrXA1Knw3XeQnp7z+m5uEBqq3xz79Su0b4ziDqSkQJMmbD1wjvrWHTxafQWPNfuMKkEHKesTg4PRCkCy0Q/XivMwxF/zHlTES68tWxhrsEWeif9zPF5OrcjKyiBoeR8yvM4Q/ew+vMpWgbg4+PVXeOQRe4eZLyQ5K8Tut+TslSdf5b124zmf5Ilf4zUYks16fjCTESqXLdw1Zv9ktcKhTRCTDgYPvS/zCLv2rOPt75uxYm8L4lO8AXB1Vfi0+ozTNQZQ1K0oq3quorJ/Zb0Q9eef6/5E0dF6ZOe1HnxQL7hepsxdfWrCzrKyYOVKeP99ElavIbjoGjqUPs73g54CzIBO6C0OnqigfjiYe0B6lj7X1xtKFCtc/T1F/rn8N2zbCY6VmLkpmufSuuglnRbFw4QJ0KQJrLm+JaAwkOSsELufkrNvfzlIszPNCS5yhj3HO1Clxbt6ugyzA1Qtf/9+GGRlwcGNcAFAN3eSvhPSI0nLcuRSkhex8Z6M+aYBm3wOca7+M/i7+7OkxxJqBtXMea3kZDh7FhYu1COlUlLAxUWvRjBkiPQZKswsFti6Va9tOHcuxMSggEoVJuCU1poNb3fANXgyOISC0aqnwzA7Q6LuA4mjWa98UdhrrkWeS/pff9y9+5KRkUnQqicx+SRyvOsGXMs+oN/ftm6F2rXtHWaek+SsELtfkjOlYMxTL/JWu484HedDcO1VepZxFyedmNlrIfOCJDMLjh2CmATg+hFxKusCPd91ZIn5JOcb9MJoNNI/rD9vN3sbX1ff66937JieG23VKv24Rg09h1qTJvn6NMRdkJEBly7pbccOWLxYT4mRvcoEEB/kQ8/6T/HXsjeJHNuQkg+8Co6Vbny9oKJQOlhGYop/RZ1ciOFAAjhWYOqG4wzNeIypbacy+JMt8M03et3g77+3d5h5TpKzQux+Sc7enhjJIM/W+Hpc4kzSCIpV6Kr7QtWprCeaFVelZ8DZC5CRChkJkJkA8alg8MOaFcOTY1zY5p3C4bCHwaAHCoxuOpoagTXItGaSacnEwehA4xKNcTY66mbPl1/Wc6YBdO2q50wLDbXv8xS5k5oKgwbB/Pl6RYkbUJ5efNPkSSZlhrNrZ3WM5yuy5OW2tGzSGlyagYMRqlfUyyxlZEJGlp5H0P0+rbUWeUMpkn/tg1uRgaRnZBK0ujseRRVHmvyEOayurrE/dqzQvedIclaI3Q/J2YLf40j6YxBPNfyeqEvFKVXrN8i0QMlium+LuL3UJNiyHvDFmnmS7qM9+Du5LvHlPuVs6GTwPHPdKSW8SjC+xXger/I4hgsX9BQcM2fqvm4uLjBggF6VICjo7j8fkTvnz+tO1Rs3Xt1nMICPD5QoQUqbFox1C2XSjDakni4HgLfrZSZ0H0m/jq7g8RQY0HMHennY5zmIQk2d+BnD4XQwl2fS+qMMz3ycbzp9w5MvzNL9Hwvhkk6SnBVihT05i9xuYcnEV3mtw/tkWY1YXGbi5Fdd15bVqSwjCXMjJRG2bgJ8sGZE8dr0y0z5owepGa64lt6ByTcaB+c0zM5pJDucIqnCZ+B1irrBdfmo9Uc0DG0IO3fCsGFXO+g6OekRncOG6d/FuXN6c3GB5s2lj1pBcOgQtGsHR48yr64rvz9VjyLFyxFQJBR/9wB2RB/iiw9DyVg/AJSJMsV38doTY3mi6jKcPDuA11B9nQdKgf8Nmr+FyAvKSsqvvXEtMpi09EyC1nalbIlAthQbg+Ghh/QawSdP6n8LCUnOCrHCnJxFRcEHg6cyrYf+cDh9qAXBzSfoDmhVyupRYSJ3khNh21bAE6xJpF+ez6f/8+DjP57jxIUSmIwWjAYrVmXEYFYYmr5LRp33wCGTJ6s9yYetP8TftSj8+Se89VbOmph/6tpV9xdxlKV68k1cnO4sHRYGRYrkPJaQAIsWweDBcOkS49sX4dXLL8OBjuB+DjxPgscZONAJLpehhN9xZr4wgFblYzG4tgWXlmC8Mg2G1FKLu8B6bC7GY4C5LO/9dYBRlqdY12stDds+B/v3w7vvwmuv2TvMPCPJWSFWWJOzixdhaPdfmPNUVxxMFnZs86Zmj3WQlKrnT6pazt4h3ruSkmDXNsi68sFruQiJX0HGXlDpoNKxWFL4aVML3pj/DufN7sQ1fxJKrcLH2YeJrSbyTM1nMGLQzQ3vvKNr0hwdISBAb7t2QWYmtG0LP/1UqJdgsZvTp6FZMzh8WDdRVqumpz4JDNTJ819/QVYWCni7ezBjDr0Okf2vu4yLYwpvPzGW4Q/vwujRC8wlrx50coRiRfWi5DIxschvVgsp/+uNa5EhpKZnErT2UVpXb8iPls56UICXl/7W7uNj70jzhCRnhVhhTc4G9NzI+01a4+GSxIZDrjRovQoyjfoDok5lcCkEi5nbk1IQexGOHoHMm4ywS11D1qWP+WplW95e8CbJpfcS17gPeJ2mcWhjxjw4hmYlm2EwGCAtTTdxZn+AL10KnTrpTuhNmuipOQrR36fdnTypE7OjR3UTcmrqDYup8uV47TE/xq/sjGHTcMZ1fZVn2y3E6lCEuDR/zicUpXrwZdx8OoP5ylx2RsDfDwJ89QSykpSJu8h65GuMx53BXJq3/trBO9YBHBtyhNAmHWDPHl1z9u679g4zT0hyVogVxuRs/vwUyh5uSM2SO9kS40Et57E4VGuk52EqEQQlg+0dYuFhtULMBThzDrIsYFV6s+iZ31FpkDib1EvzGfn9u8xc+xyq8Vgy604AczqVi1ZmcN3BPFntSSxWC2eTzhKTFIOjyZH6x7MwPtRBN6/VrAkvvggREXpBY/HvHT+u+/NFRUGpUnqqEycnWLsWVq+GmBguNanDokpm5l1YzaLPwzCsGc0Xzz5H70eKgksrwAwGB71lM1ogNASCA8BB+goKO7FmkfJrH1x9h5CcmkHAllYMCh/MhORw/YXPzU3/7Rctau9I/zNJzgqxwpacXboEUwe9yegO73Ax1YXMvxoROHiSXgXA0x2ql5dBAHdDciociYa4RP046yTEvce3K8rR78uZmIskk9ZoFBkPzAaTBQMGFFfeOrIcIbko3Rs2YVboUJzaddArEYCuhalbF9q00TU/9eqB85VaUKX0cPm1a/Xv+PHHddJxv1JKJ2J79ujJgdPS9KTAEyZAdDSp5Uvx6tjm/HJqGe6O7vi6+OLr6sul5DjWbb+I9WRtiGqOYc8TfNZnAM92DgXXiOvvY8iC4oEQWlzmKRMFQvruGTjFBoBDKCM2/cGXTOLksGjcGjWDbdv0F70PPrB3mP+ZJGeFWGFLzp57Zg1THmyNkzmDDYvdaDBiG8Ql6VUAwirpPjDi7lAKzl+Goyf1nFYAyb9y4OBy2r/3Hcdiy+BXPA5j4/eJLfUxRDfGvP8pLPsexprqCa1eoukT21gQPhmfWT/AH3/A33/nvIeTE9Svr/tJrVun+1Flq1ABZszQSVxhpJRe2/TLL3WfvKAgvbm4QGQkbNgAMTE3PHVX3RJ0f9yF/fP7wvY+eqcpQ2/pnpCR/V6gmNF7EP0fDQDX9oCCB8qAp5tOlA0GXUsmX3hEQZKVQvpvz+Lk+wJxyWkERrbg47aT6X+xlP5i5+ysm/SL3duDVCQ5K8QKU3I2f0EiobtbUq/sFjaf8KZe6S8gsIQ+WLWcHggg7r4sC0SdhjOx+rElloxLU5m9rDzzNzzEmv1NsWLGYjHg6RJP1ZDdeLvF8cfOtlhbv0ilh5ex+InFlPAuoZOvJUtgxQrdBHf2bM57mc26Zu3o0auJyZNP6m/JAQF39Wnnq6go6N9fd9y/FbMZqlQBb29wdsbq4szkMud52XkXmT/Ngv1dbEWdzGkU9ThPCb8ThJXZRbOaewkrtY2QYhHg9gig9PqzfoWjM7Uo3C6tGU2RrDrgEMjAHV+y2ryGvQP2YGjaVH+RGzgQpk2zd5j/iSRnhVhhSc4uXYIP+r/NuI6jiU93xmFlc9z6vaP7REk/s4IhLhEOHIF0i36ceQhSFpF0eR1bD5emTGAUoX4JYC4PRk9mLQmlz+czUW2HUPTB+XSs2JHGoY1pFNqIkt4lMYAeabh6tW72DA+H+vWJscRjiE8gYPwUmD5d1zA5O+v+ah07QocO4HuL+bas1qu1QgVNUhJ89pme0DclRdccvvIKFC+uE9WzZ3UfvWrVoEEDCAsj3Wxk9fHV/HbwN3479BunYhPgh//Biaa8/PAHvNp1Ju6mGIzWa2f9dwDnxuDWGZzrY6sx8y9ys8iEKFhSz5G15AUcigwnJiGZkB0tmN/1Jzqe89Gjks1m/SUuJMTekf5rkpwVYoUhOdu7F94c/Cvf9uyOi2Maexe4UnnYX5BlBW8PqFa+YH7Q3o8sVjh+Ek7HgrryO1FZkLEPHILAdE0n3dRVTP/xJINmTYb2AyBsJhj120ugeyDVAqpRpWgVqvhXwcnBibUn1rL6+GoOXjyIAQOD6w7mXa9OeA4doZv5splMuim0bl2oU0cviJyWBsuXw7JleloPb28YMQKee043E96KUv/+72vxYhg7Vs8z9sILuoP+Px0+rMstWqRjy8jQ+5s2JWnaJFY5nCLQPZDK/pVxNespR+LS4lh8eDG/HviVxYf/IDnBBAkhEB+CcdV7OJyvwJwBfXm8lbNurrRehqyzYIkBsx84NQWD29UYKpbSoy+FuIec+nkAxX06gsmXZ/a8xwa1mz0D9mBu2Vp/qXv1Vf3/7x4lyVkhdq8nZwvmxZK0djhPNfwOgH3H3akU8AmUraz7wtSuLP3MCqLMLDh/SY/0TEzJeczF6crUDkZIW8eH38bw0rfjcXDKxDEgilTvSJT/Tii7FAL+1ssCAVgNcCoc9nQHqwkavUdwiIWpbafQKaMMLFigt3/2W7uVwEAYORL69Mk5lUdmpm5S/PZb+N//dN+VF1+EXr1un8yBrul74QV9fjajER57DIYMgdhYff0//9SDHK5VqhSMGsWfD4bQe+6rnP67LBSLxOh7nHJFyuHv5s/GUxvJii0F61+GvY9d04cM/DzO8/vIztSrdaVm7GYczTohC/QF1zt4TkIUMNa4AxjXjgWv5zkRH0fpHRFMbjuZwaeDoXNnPfL75Mmrg4ruMZKcFWL3anJmtSjmvT+HVkVews/jIlargS27Ham3vR6GNz7StRnybf/ekJwKicl67jl3F12zdTkBdh8AZYS0LXz0XQyTFj3L2bggLNarIwLdfOPwqrIB5XyR5B3tSYi92uxmcEpCtXwJwmbSulwrulXuRtuybQk6n6onWN22Tc+Ov3OnToyaNiWjxYNsquGHx6Hj1Hz/Gzhx4mqcPj564eRixfS5589f/1z8/eH556FyZTh1Sm9nzuiELTBQd9jPytKrI5w/D0Yj6f2fxelI1M37j5nNeq63du2gXTsuh/oz5Nc3+O6zANg4HDKvTAYcvBmq/ABB22HrINj3GCgjTuY0Qn2jqV4miuplo3i24YcEFO8Jrm0ABWVC9ReYtHRIywBl1f3KfDylxlnc86Jmd6ZUiYFg9Gb4kUl8fXEpRwcexKtSTZ2Yff01PPWUvcP8VyQ5K8Tu1eRswcdf0clfjzL7+0IgJ/6IpcPeYPjuF7Cil2aqXEY+XO5lcYnw915QDpD+NyT/iDVjL4npBo5fLMvP61rz69Z27D5ZFTBQKXgvvR78nqcfnAuWTEb9MIZZa57BUGo1qkNfKKJroGoF1aJxaGOKeRQjyD2IQJeiHI8/zuJjS1l+bDlJGbrvVXhwfV5KrckjU5ZiOnLs+vj8/aF7dy51bovLzj24fDQ1ZzJ3GynVK/H2i7X56PgP1AyqyVslehHxzQYMP86HkiUhIoK0lg+ypZwLh1NOc+zyMfYcvczK3wJIWjkIUv1oXXUpQ9p9ye/bWvLd+u4kpV1dVLxumc1M7vce9Yr/hoEr884ZXMDnbXB5UD9+oLT0IxOFWtLR1bjvngI+r5JhySJs+5O0r/Eo723x1BPS1q0LmzfbO8x/RZKzQuxeTM72/52I97ryBHnHMGVfVSrM302ETz34Yg5cTNTNmXWq6GYZcW9LSIKde3SCls1yETL2QOYRyDpGQkoSSWkOFPNOA4dS4FBST36b9DVr9lWn3xefcuhsBZyKniQ9cC0Eb4Fi26DoPnCJu+ZexeBIG5xOPEym6TLWGjMhZCNlipThyfKPUs0QSOVkN8qcz+KYv5kFvuf55dCvbDm9BU8nT3pVfZoB50Ko+NVvul9Y8eJ6K1ZMN9PGxOjt4kWWRZSjv+cajm0tD5uf1/HUnUr9imV4teEoYlPO8/vh3/lzzxZS9j0IUc3gRFO4pJcd83a9zGcDnqdrrW9s4WcodxbvfYIFGx5kZOeZVPZbrQdXONUFx0rgVAkMQWAw6qbgyrK+rLgPKEX0F/UIDekOLo35O+kwjXc+x9+Pr6JEpQb6/+qWLbr/6T1GkrNC7F5LzrKyYPbwl+hb/0MOXwzi4PSzPFSvJ4ydAEdP6ebMB0qBvzRnFhopqXDmvE7UklLgTt9hrHEQN5GMpNV8/Mfz/Pl3a7Yeq0NC6tUpVRy9LmIOOIxK8SPlVNnrLmEq9jeWsKlQZS446Ro1s9FMpjUTkn1hy2DY3hecEqHq91DtW1rUKkPd4LpYlRWlFAqFVVlt24n4E/y69iD8+SEcaXv1Zg6pUGM21JkG5yvpvnOH24Hl6kS6BqOVZx+ex0ddXsTNeBZcIsC3N6SfgrS9erJfa4oeYencVA+y+CcnR6hQUjdbCnEfiD/yF17bOqL8f8BgKsIHJ79lp+sFvl1g0P0+e/aE2bPtHWauSXJWiN1rydmMicfo7f8ATuYMRv9VhLf8h8CjPeBSvC7g5wOVSktzZmFlsUJSsh5EkJKqk7XkJD0YwNlRL83i6qz/HpKvrBeZuhriJoD1AkoZiI6vxLqDDfjf5pas2NuCS0m+gKJOmW0M7/Qd7ar8RHqWmelLevPZ8j6cjSuGwZSFa+h+0oOXk1XsLwzRzTBsfxazggcfWM3FJF+2HasNGCBkHRTdDxYzWBzBagZjlk6+HNL0JK97HsfLJYkX2k6mX5u57DtdmZfnvEJkVO3rnnL1qukMeHQ9rSv/TqjD75iSD+sasSJvgEPFW79eRiP4eICHG7i76k0GyIj70L7Pu1PJ9zT4foRVWWmxayBTKr9A1VZP6ilpTp6855Z0kuSsELuXkrN9+2D/513oUucXlscEUfNIe3y7D7g6L1VoIIQGyWzl95vst5xrE3KrFU7GwImzV44rsJyDjEOQdQwy9kP6FpRK5qK1Fo7GBDw5DA4lwLkZqFRI+R2rNY3lBx7mm9WdOH6+JMfPl+RsXBD1ym7mqUbf8ETDeXg6xwEQHVeBGUt78s26pzh9qfhNw/VyjeP5NpMZ2WESbk4K3DpCxl7IiGTn2Ra88vVLhBTL4ImIzdQptRn39C2QlQEOxcEhBFwag2sHwKD/1ov7g9F0ZXmmdD0S1stdN1n6eOgBFkLc59IunsS6sCKu/sPArRMn084xIf13Pnl7q55qZ/x4PWfgPUSSs0LsXknOsrJg4GMrmflYCyxWIxsOP0rj5iP0QU93KF8C3GS4v/iHpBQ4dEKPBv0nZYGMnZC2DjDrdSPNZa45ngpJP0LSD2C9aNttVQaMBgWmIHDrCm7tdeIXP/VKwmcg2eIPBiMKI2DCQCYm0jEaMnAwpGIyWMCpARQZA8YrM+6n74CEmZCxDTCCYw1waQ7ODcFUTPcVu5Z/EShdXGrChLhDkV+PJcw8liy/H3FwDOSFo5N4TdXHr+9QPRL76NF7an3Y3Hx+F5gqi/feew+DwcCwYcNs+9LS0hg0aBC+vr64u7vTpUsXzp07l+O86Oho2rdvj6urK/7+/owYMYKsrKwcZVavXk2tWrVwcnKibNmyzL5BW/W0adMoWbIkzs7O1KtXjy1btuQ4fjdjudcpBUOHWBhYdzgAC84Xp1GDwfpgiWJQo4IkZuLG3F2h1gMQXl1PRlw2FIKK6qZPgwmcwsDrefAaqBMzg0Ev8+XqrEc2evSEoEUQ9DX4jQWPPhjdHgLfDyDwV/B4UidX5orgNw2CZmMwh+LucA53cyoeLkXx8KiOu1tFXJx8cDJmYjI6gv8E8Jusz3Vy1Pd1qglFZ4D/dxD0JxT9DNy76Rozg1HXgHm46qSsegU90lISMyHuWI3HX+TUpUAcUr4GoF9gRz4vfVmvGBIdDb/8YucI80+BSDm3bt3KZ599RrVq1XLsf+GFF1i0aBHz58/Hy8uLwYMH07lzZ9avXw+AxWKhffv2BAYGsmHDBs6ePcvTTz+N2Wxm3LhxAERFRdG+fXv69+/Pd999x4oVK+jbty9BQUFEREQAMG/ePIYPH86nn35KvXr1+Pjjj4mIiODgwYP4+/vf1VgKg7FjoWT8KGqU2MXlDDONDQMwOLvofjQlgqR/mbg9R7Peru0En5qu+6Zd21/RzxvMDvobwcV4OHkWEpLB+AA4PQBO/7iujycUK6qn/ThzHoyVIfAn/TXVcpNYjAawXmlgCPaHUsV11XB0DJw9r/uTgR517Oet4/Jw03HJ37oQ/5rJ0ZmY4I8onvIkynMwD7iV4q3Ds8gc1B/z22NhwgQ9EXRh/H+m7CwxMVGVK1dOLVu2TDVt2lQ9//zzSiml4uLilNlsVvPnz7eV3b9/vwLUxo0blVJKLV68WBmNRhUTE2MrM2PGDOXp6anS09OVUkqNHDlSVa5cOcc9u3XrpiIiImyP69atqwYNGmR7bLFYVLFixdT48ePveiy3Ex8frwAVHx9/x+fcTZ9/rtTQiI+V+g6lvkMteK+BUqu36i0x2d7hiftBfKJSp2OVOnZKqf3HlNp5QKmDx5VKSslZLjlFqb8PXf37XL1VqU27lNp1UKnIfUr9tf3q/o27lLp0g/9zaelKnTqn1MU4pSyWu/P8hLiPWC1WtX1iU6V+H6HU6q3ql/nvq3kbPlfKxUUpUGrZMnuHeMdy8/lt92bNQYMG0b59e1q2bJljf2RkJJmZmTn2V6xYkdDQUDZu3AjAxo0bqVq1KgEBAbYyERERJCQksHfvXluZf147IiLCdo2MjAwiIyNzlDEajbRs2dJW5m7FciPp6ekkJCTk2AqqhQth+ZfzmPTkCwBMP+HEwyVG6oPFA3STlRD5zdNd146VCtarTlSvcOM+jq4uULWcXjIsrBI0qgn1qunm1FoPQMMaunm11gNQp/KNp7JwctS1aUW8ZGCLEPnAYDSQVfZFSP4JgIf9mjDv8K96iTbQtWeFkF3fTebOncv27dsZP378dcdiYmJwdHTE29s7x/6AgABiYmJsZa5NhrKPZx+7VZmEhARSU1O5cOECFovlhmWuvcbdiOVGxo8fj5eXl20LCQm5YTl7++EH+OTNVczp/zRGo2LOOXj6VB+MQcH6A6xkMXuHKMSNubnoLw7/HCVpMOimVQ83GUEphB2FdWhPdKwR0rZiMpgIowSRvVrr/5fLl+vRm4WM3ZKzkydP8vzzz/Pdd9/hfI8uYno3jBo1ivj4eNt28uRJe4eUQ1oaDBgAv3w8nx8HdcTJnMFvcQaaza+Ce5endaGyIfLhJoQQ4l8xmoyc9RoKyT8C8GxQR6ZH/wLduukC779vx+jyh92Ss8jISGJjY6lVqxYODg44ODiwZs0apkyZgoODAwEBAWRkZBAXF5fjvHPnzhEYGAhAYGDgdSMmsx/froynpycuLi74+flhMpluWObaa9yNWG7EyckJT0/PHFtBcewYPNQylmbmrsx/vitergn8lQyl55Yj9I1PdEKW3UFaCCGE+Jdqdu5FYtwOyIqhqKMP1tiLnB36jD740096Wo1CxG7JWYsWLdi9ezc7d+60bbVr16ZHjx62n81mMytWrLCdc/DgQaKjowkPDwcgPDyc3bt3ExsbayuzbNkyPD09qVSpkq3MtdfILpN9DUdHR8LCwnKUsVqtrFixwlYmLCzsrsRyLzl2DN7q+xM/PFmZrvXnk2k1MDHWgNM3pakycga4uum+PxVL2TtUIYQQ9zhHN08OZj0DyT8D0D+oM5MS/oS2bfUk1h98YOcI89hdGKBwx64dramUUv3791ehoaFq5cqVatu2bSo8PFyFh4fbjmdlZakqVaqo1q1bq507d6olS5aookWLqlGjRtnKHDt2TLm6uqoRI0ao/fv3q2nTpimTyaSWLFliKzN37lzl5OSkZs+erfbt26f69eunvL29c4y8vFux3E5BGa355rOLbSMyd35uVk+97KTOVAxVasFSPbotcq9SmZl2jVEIIUThkXDmqLJ8V0SpVeuVWr1VtZ/WRF1atlCP2nRyUur0aXuHeEu5+fwu0MlZamqqGjhwoPLx8VGurq6qU6dO6uzZsznOOX78uGrbtq1ycXFRfn5+6sUXX1SZ/0gKVq1apWrUqKEcHR1V6dKl1axZs66799SpU1VoaKhydHRUdevWVZs2bcpx/G7GcisFITlb9FuKOjqplFLfob78yFMN6+SoMsqVVernxTox27pHqQxJzIQQQuStPdMfUer3l5RavVXt/P079c7qt5Rq2FAnaM89Z+/wbik3n9+yfNM9xt7LN6WlwRdDX2Pwg+M4mejFnF/ieV21hRGvg6Ojnqm9egU9yk0IIYTIQxf2rsZvd0eU/wIMJg9eOPYx75Z6GrdmEbqf8759UL68vcO8oXty+SZxb5j18X76NZoIwNtnLLxceQS89rZOzHw8oUZFScyEEELkC79KTYmOL4Mh8XMAXin+FHOcDkL79mCxwOuv2znCvCHJmbhjx6MUlVMG4OiQyaJzpRlb8mPMj3TVB0sE6Qk9zQViRTAhhBCFkcGAa/g7kDwfa0Y0AY6+qOgzpL/7lp6bcP582LbN3lH+Z5KciTv225SvaVJxDckZzmR5dsK/dHUwGaFKWSgZXDjXNxNCCFGg+FVtS1RSPYyJHwPQ178DC7L2wpNP6gKjRtkvuDwiyZm4I99+cZbuFV4CYFZCPR4ufaXGrFIZ8PW2X2BCCCHuLwYDPg+Og7S/sKZuwcnoiNfpBLLGvKm72Cxfrrd7mCRn4rZWr0ij3JlOFPW8wO7LxXgkdCAGoxGK+ug1BYUQQoi7yLt8Ew4nR2BM+AirstLWuz4Lz23QS9YAvPyy7oN2j5LkTNzSoYOKM//rT72ym7mU6sYaj4cI8SkNVguUK2Hv8IQQQtynAiPGQtZRDMm/AFD+sjMXh/cHDw/Yvv2eXtZJkjNxU5cuwc/jJvFE/TlkWUy8nFScAcWvLJdRWTr/CyGEsB+P0DAOpnbBkPgpGRkpVHYrzYoDy2HqVF3gzTdh61b7BvkvSXImbigzEyYMW8LIViMAeCnGnZeKvYLJ5ABGq27SFEIIIewotP3bWLIScUyZAkArYyX2tagBXbtCVhb06AFJSfYN8l+Q5Ezc0Edv7GRU48cxGa18EeND/aIDqeBfBTLSoW4NGZkphBDC7lwCK3HEOASSF5CRGoWP2ZOjO/9CzZgBxYvD4cMwbJi9w8w1Sc7EdRbMOcAzJVrj7RbP2otFiPZox+OlOuvFZSuXAydHe4cohBBCAFD+sXGcii+DY9J4ANq712XlyfXwzTe6IuHLL+Hnn+0cZe5IciZy2L3pOHUSW+LvdZ7I80F8ZqrGW2WH6oP+3lDM367xCSGEENcymF2x1puDJW0XpCzBaDDifSqeC3Uq61GbAP36wcWL9g00FyQ5EzYXT57Bc2sLihc5zd7YEF6x+jC73Dt62gyTgkrl7B2iEEIIcZ3QWuFsuPwSxE/Fak0lzL0ify3/jsRRL0LVqnqE21tv2TvMOybJmQAgM+kCib+1ooTvMY5eCKF3shM/VfgIs6MzpCZBw9rSz0wIIUSBVfuZtzh0tijGy6+jlJVO3o34edXnpH84QReYPh0OHLBvkHdIkjMBwM71x/F2PM2pS8XodsaPn6u9j5ebLyTEQcvGkpgJIYQo0FzcnTlfdg5ZyesxxOs5znp5t+LLtK1YOjykJ6V96SU7R3lnJDkTAFR8sAJPHW3FI3urMqf+cIp7hkDcJWjRCBxM9g5PCCGEuK2GHcL4/vB0SP4ZEmcB8Kx7az7tWQ0cHGDRIvjzTztHeXuSnAkAdsfuZp3XMia1eoTKPhUhMQHqVgNXZ3uHJoQQQtyx7m/0Y9b2sZAwHVIWYzY68KR3K5a/3E0XGD5cz4FWgElyJgBoUDycYyWm0cS3DqSkQHE/CAq0d1hCCCFErpjN0OWNUXy7bRhcfgeVvhcvB3cSa9UkKcAH9u6FL76wd5i3JMmZ0Fasxie4gl4aICsJalSzd0RCCCHEv+LpZaDZ8A/5KbI7hvj39AAB36bMebOzLvDOO/YN8DYkORNa86awdwcc/Bs6tLN3NEIIIcR/ElzcSIWeX/LX3gDb4uhNS7YisrgJzpwBpewc4c1JciY0oxEGPguDnrN3JEIIIUSeqFrNTGzJL0m5MAssl6niVobVw7uRZUSP3iygJDkTQgghRKHVuWcZvt/9CiR8AsBz1frxZUs/3Y2ngJLkTAghhBCFlsEA7YcPZeve85CxG3cHN4r0er5Aj9iU5EwIIYQQhVpQMROxpb4g4+JUADoFtkBlZNg5qpuT5EwIIYQQhV677pX43/7HAHAwmslKT7VzRDcnyZkQQgghCj2DAap27mp7nJGWYsdobk2SMyGEEELcF7x8rq56k56aZMdIbk2SMyGEEELcF5ydXW0/p6dIzZkQQgghhF05u1ytOUtLSbNjJLcmyZkQQggh7gsOTo6g9OSzmalScyaEEEIIYVcODkZAz2+WkSGT0AohhBBC2JXBaEBdqTnLypBmTSGEEEII+7uSnFlk+SYhhBBCCPuz1ZxJciaEEEIIYX/ZyZlF1tYUQgghhCgAbMmZ1JwJIYQQQthdds2Z1Wq1cyQ3J8mZEEIIIe4b1ivJGRaLfQO5BUnOhBBCCHHfUErXmCmrsnMkNyfJmRBCCCHuG9k1Z9lJWkEkyZkQQggh7hvqSl8zpaTmTAghhBDC7qzZNWYFODlzyO0JFy9e5M0332TVqlXExsZeN9rh0qVLeRacEEIIIUReys5bDBSi5Oypp57iyJEj9OnTh4CAAAwGQ37EJYQQQgiR57L7mhWq5Oyvv/5i3bp1VK9ePT/iEUIIIYTINxZbzVnBrVzKdZ+zihUrkpqamh+xCCGEEELkq+w+ZwW54S/Xydn06dN57bXXWLNmDRcvXiQhISHHJoQQQghRUF3tc1Zw5bpZ09vbm4SEBJo3b55jv1IKg8GApQDPuCuEEEKI+1t2s6axAFed5To569GjB2azme+//14GBAghhBDinpI9z1lBzl9ynZzt2bOHHTt2UKFChfyIRwghhBAi31iu9DkzFuCZXnMdWu3atTl58mR+xCKEEEIIka8sV9bUNBXgefhzXXM2ZMgQnn/+eUaMGEHVqlUxm805jlerVi3PghNCCCGEyEvZAwKMxoLbrJnrtLFbt27s37+f3r17U6dOHWrUqEHNmjVt/+bGjBkzqFatGp6ennh6ehIeHs4ff/xhO56WlsagQYPw9fXF3d2dLl26cO7cuRzXiI6Opn379ri6uuLv78+IESPIysrKUWb16tXUqlULJycnypYty+zZs6+LZdq0aZQsWRJnZ2fq1avHli1bchy/m7EIIYQQIn9k15wZC3C7Zq4ji4qKum47duyY7d/cKF68OO+99x6RkZFs27aN5s2b88gjj7B3714AXnjhBRYuXMj8+fNZs2YNZ86coXPnzrbzLRYL7du3JyMjgw0bNjBnzhxmz57Nm2++mSPe9u3b06xZM3bu3MmwYcPo27cvS5cutZWZN28ew4cPZ/To0Wzfvp3q1asTERFBbGysrczdikUIIYQQ+ceanZwV4AEBqALGx8dHffHFFyouLk6ZzWY1f/5827H9+/crQG3cuFEppdTixYuV0WhUMTExtjIzZsxQnp6eKj09XSml1MiRI1XlypVz3KNbt24qIiLC9rhu3bpq0KBBtscWi0UVK1ZMjR8/Ximl7mostxMfH68AFR8ff8fnCCGEEELb++UkpVZvVbs/n3RX75ubz+9c9zn7+uuvb3n86aef/ldJosViYf78+SQnJxMeHk5kZCSZmZm0bNnSVqZixYqEhoayceNG6tevz8aNG6latSoBAQG2MhEREQwYMIC9e/dSs2ZNNm7cmOMa2WWGDRsGQEZGBpGRkYwaNcp23Gg00rJlSzZu3Ahw12IRQgghRP66UnFWoPuc5To5e/7553M8zszMJCUlBUdHR1xdXXOdnO3evZvw8HDS0tJwd3dnwYIFVKpUiZ07d+Lo6Ii3t3eO8gEBAcTExAAQExOTIxnKPp597FZlEhISSE1N5fLly1gslhuWOXDggO0adyMWFxeX616f9PR00tPTbY9lFQYhhBDi38seEGAqTH3OLl++nGNLSkri4MGDNGrUiB9++CHXAVSoUIGdO3eyefNmBgwYQM+ePdm3b1+ur1NYjR8/Hi8vL9sWEhJi75CEEEKIe5ZtKg1DIUrObqRcuXK8995719Wq3QlHR0fKli1LWFgY48ePp3r16kyePJnAwEAyMjKIi4vLUf7cuXMEBgYCEBgYeN2IyezHtyvj6emJi4sLfn5+mEymG5a59hp3I5YbGTVqFPHx8bZN5pgTQggh/r2rzZqFPDkDcHBw4MyZM//5OlarlfT0dMLCwjCbzaxYscJ27ODBg0RHRxMeHg5AeHg4u3fvzjGqctmyZXh6elKpUiVbmWuvkV0m+xqOjo6EhYXlKGO1WlmxYoWtzN2K5UacnJxsU41kb0IIIYT4d6zqSs1ZAU7Oct3n7LfffsvxWCnF2bNn+eSTT2jYsGGurjVq1Cjatm1LaGgoiYmJfP/996xevZqlS5fi5eVFnz59GD58OEWKFMHT05MhQ4YQHh5O/fr1AWjdujWVKlXiqaee4v333ycmJobXX3+dQYMG4eTkBED//v355JNPGDlyJL1792blypX8+OOPLFq0yBbH8OHD6dmzJ7Vr16Zu3bp8/PHHJCcn88wzzwDc1ViEEEIIkX+sV/4tyAMCcj2VhsFgyLEZjUYVEBCgunfvrs6cOZOra/Xu3VuVKFFCOTo6qqJFi6oWLVqoP//803Y8NTVVDRw4UPn4+ChXV1fVqVMndfbs2RzXOH78uGrbtq1ycXFRfn5+6sUXX1SZmZk5yqxatUrVqFFDOTo6qtKlS6tZs2ZdF8vUqVNVaGiocnR0VHXr1lWbNm3KcfxuxnIrMpWGEEII8e9t+GSiUqu3qtNzP7+r983N57dBqSv1e+KekJCQgJeXF/Hx8dLEKYQQQuTShmkf0KDKg8TE7ibwsWfu2n1z8/n9nxtcLRYLO3fu5PLly//1UkIIIYQQ+epemOcs18nZsGHD+PLLLwGdmDVp0oRatWoREhLC6tWr8zo+IYQQQog8k91caDSY7BrHreQ6Ofvpp5+oXr06AAsXLuT48eMcOHCAF154gddeey3PAxRCCCGEyCvWK2tqmgpTzdmFCxds83YtXryYxx57jPLly9O7d292796d5wEKIYQQQuQdnZQZjYWo5iwgIIB9+/ZhsVhYsmQJrVq1AiAlJQWTqeA+USGEEEIIdaXmzFiAVwjI9TxnzzzzDF27diUoKAiDwWBbyHvz5s1UrFgxzwMUQgghhMgzV/qaGQrTJLRjxoyhSpUqnDx5kscee8w2warJZOKVV17J8wCFEEIIIfKMMbvmrOC29uU6OQN49NFHr9vXs2fP/xyMEEIIIUS+MurUpyA3axbcyIQQQggh8pjBlN2sWXBrziQ5E0IIIcR9w5acFeBmTUnOhBBCCHHfMJjMgDRrCiGEEEIUCCZHnZwVqpqz7du355hs9n//+x8dO3bk1VdfJSMjI0+DE0IIIYTIS0YHRwAMhanm7LnnnuPQoUMAHDt2jMcffxxXV1fmz5/PyJEj8zxAIYQQQoi8YroyBRgGB1Dq1oXtJNfJ2aFDh6hRowYA8+fPp0mTJnz//ffMnj2bn3/+Oa/jE0IIIYTIMw6O19ScZWXZOZoby3VyppTCarUCsHz5ctq1awdASEgIFy5cyNvohBBCCCHykIOTi/7B4FB4krPatWvz7rvv8s0337BmzRrat28PQFRUFAEBAXkeoBBCCCFEXjG76uTMYDCj0tPtHM2N5To5+/jjj9m+fTuDBw/mtddeo2zZsgD89NNPNGjQIM8DFEIIIYTIKw7OLrafMzNS7RjJzRmUypvecGlpaZhMJsxmc15cTtxEQkICXl5exMfH4+npae9whBBCiHvKyWNRhJy8CEBSqBfupcrdlfvm5vP7X62teSPOzs55dSkhhBBCiHzhfE3NWWpKMu52jOVm7ig58/HxwWAw3NEFL1269J8CEkIIIYTIL07Orraf01MKZrPmHSVnH3/8cT6HIYQQQgiR/5xdrrb0ZaSk2DGSm7uj5Kxnz575HYcQQgghRL5zcDSDygKDA5npafYO54b+1doFR48e5fXXX6d79+7ExsYC8Mcff7B37948DU4IIYQQIi8ZTQaU0vObZRaWqTTWrFlD1apV2bx5M7/88gtJSUkA7Nq1i9GjR+d5gEIIIYQQeUtPpp+RUUhqzl555RXeffddli1bhuOVJRAAmjdvzqZNm/I0OCGEEEKIPHel5iwro5CsELB79246dep03X5/f39ZvkkIIYQQBZ5SFgCsWRl2juTGcp2ceXt7c/bs2ev279ixg+Dg4DwJSgghhBAiv2QnZ5Ysi50jubFcJ2ePP/44L7/8MjExMRgMBqxWK+vXr+ell17i6aefzo8YhRBCCCHyTHZyprIy7RzJjeU6ORs3bhwVK1YkJCSEpKQkKlWqRJMmTWjQoAGvv/56fsQohBBCCJFnlNIDAiwWq50jubFcL9/k6OjI559/zptvvsnu3btJSkqiZs2alCt3d9amEkIIIYT4L2w1Z9ZCMiBg1apVAISEhNCuXTu6du1qS8w+++yzvI1OCCGEECKPWa/UnGFV9g3kJnKdnLVp04YRI0aQmXm1nfbChQt06NCBV155JU+DE0IIIYTIa8p6peZMFcxmzX9Vc7ZgwQLq1KnDvn37WLRoEVWqVCEhIYGdO3fmQ4hCCCGEEHmn0NWcNWjQgJ07d1KlShVq1apFp06deOGFF1i9ejUlSpTIjxiFEEIIIfKM1ZpdY1ZIkjOAQ4cOsW3bNooXL46DgwMHDx4kpYCu7C6EEEIIca3sAQGGwpKcvffee4SHh9OqVSv27NnDli1b2LFjB9WqVWPjxo35EaMQQgghRJ6xZjdnFszcLPfJ2eTJk/n111+ZOnUqzs7OVKlShS1bttC5c2cefPDBfAhRCCGEECLvWK4MCDAY7BzITeR6nrPdu3fj5+eXY5/ZbGbixIk89NBDeRaYEEIIIUR+sCpdZfav+nbdBbmO65+J2bWaNm36n4IRQgghhMhv2QMC7umas86dOzN79mw8PT3p3LnzLcv+8ssveRKYEEIIIUR+sF5p1jQW0OzsjpIzLy8vDFeegKenp+1nIYQQQoh7jeVKs2ZBTWfuKDmbNWuW7efZs2fnVyxCCCGEEPkue7SmqYBmZ3fc58xqtTJhwgQaNmxInTp1eOWVV0hNTc3P2IQQQggh8lx2nzOjsWAOCbjjqMaOHcurr76Ku7s7wcHBTJ48mUGDBuVnbEIIIYQQec6SnZzd6zVnX3/9NdOnT2fp0qX8+uuvLFy4kO++++6aJRCEEEIIIQo+W3JmvMeTs+joaNq1a2d73LJlSwwGA2fOnMmXwIQQQggh8oNtnrN7veYsKysLZ2fnHPvMZjOZmZl5HpQQQgghRH6xZA8IKKB9zu54hQClFL169cLJycm2Ly0tjf79++Pm5mbbJ/OcCSGEEKIgy645MxXQZs07Ts569ux53b4nn3wyT4MRQgghhMhv2VNpGA33eM3ZtXOdCSGEEELcq7InoTWZCmZyVjCjEkIIIYTIJ4VmQEB+GD9+PHXq1MHDwwN/f386duzIwYMHc5RJS0tj0KBB+Pr64u7uTpcuXTh37lyOMtHR0bRv3x5XV1f8/f0ZMWIEWVlZOcqsXr2aWrVq4eTkRNmyZW+40sG0adMoWbIkzs7O1KtXjy1bttgtFiGEEELkj+xZwO75SWjzw5o1axg0aBCbNm1i2bJlZGZm0rp1a5KTk21lXnjhBRYuXMj8+fNZs2YNZ86cybH4usVioX379mRkZLBhwwbmzJnD7NmzefPNN21loqKiaN++Pc2aNWPnzp0MGzaMvn37snTpUluZefPmMXz4cEaPHs327dupXr06ERERxMbG3vVYhBBCCJF/rBTs0ZqoAiQ2NlYBas2aNUoppeLi4pTZbFbz58+3ldm/f78C1MaNG5VSSi1evFgZjUYVExNjKzNjxgzl6emp0tPTlVJKjRw5UlWuXDnHvbp166YiIiJsj+vWrasGDRpke2yxWFSxYsXU+PHj73ostxIfH68AFR8ff0flhRBCCJHT+k/eV2r1VnV63hd37Z65+fwuUCljfHw8AEWKFAEgMjKSzMxMWrZsaStTsWJFQkND2bhxIwAbN26katWqBAQE2MpERESQkJDA3r17bWWuvUZ2mexrZGRkEBkZmaOM0WikZcuWtjJ3K5Z/Sk9PJyEhIccmhBBCiH/vymDNAltzVmCislqtDBs2jIYNG1KlShUAYmJicHR0xNvbO0fZgIAAYmJibGWuTYayj2cfu1WZhIQEUlNTuXDhAhaL5YZlrr3G3Yjln8aPH4+Xl5dtCwkJua6MEEIIIe7cldyswE6lUWCiGjRoEHv27GHu3Ln2DqVAGTVqFPHx8bbt5MmT9g5JCCGEuKdZlR6lKQMCbmHw4MH8/vvvrFq1iuLFi9v2BwYGkpGRQVxcXI7y586dIzAw0FbmnyMmsx/froynpycuLi74+flhMpluWObaa9yNWP7JyckJT0/PHJsQQggh/oMrU2hIzdkNKKUYPHgwCxYsYOXKlZQqVSrH8bCwMMxmMytWrLDtO3jwINHR0YSHhwMQHh7O7t27c4yqXLZsGZ6enlSqVMlW5tprZJfJvoajoyNhYWE5ylitVlasWGErc7diEUIIIUT+UoaCXXNm19GaAwYMUF5eXmr16tXq7Nmzti0lJcVWpn///io0NFStXLlSbdu2TYWHh6vw8HDb8aysLFWlShXVunVrtXPnTrVkyRJVtGhRNWrUKFuZY8eOKVdXVzVixAi1f/9+NW3aNGUymdSSJUtsZebOnaucnJzU7Nmz1b59+1S/fv2Ut7d3jpGXdyuWW5HRmkIIIcR/s+qTj5RavVUlLpx31+6Zm89vuyZn6D55122zZs2ylUlNTVUDBw5UPj4+ytXVVXXq1EmdPXs2x3WOHz+u2rZtq1xcXJSfn5968cUXVWZmZo4yq1atUjVq1FCOjo6qdOnSOe6RberUqSo0NFQ5OjqqunXrqk2bNuU4fjdjuRlJzoQQQoj/ZtX0SUqt3qqSfp9/27J5JTef3wallLpZrZooeBISEvDy8iI+Pl76nwkhhBD/wupPP+HBB+qTmhyNS7vOtz8hD+Tm87uANrYKIYQQQuSTKwueGwpon7OCGZUQQgghRD4xmEwAGA0mO0dyY5KcCSGEEOK+YjA6XPlXkjMhhBBCCLszOZgBMBTQNKhgRiWEEEIIkU+MZqk5E0IIIYQoMIxmRwAMSHImhBBCCGF3JscryZkMCBBCCCGEsD8HRyf9g8EBCuB0r5KcCSGEEOK+YnZ20T8YTJCVZd9gbkCSMyGEEELcV8wuOjkzGBywpqfZOZrrSXImhBBCiPuKo4ur7efMtBQ7RnJjkpwJIYQQ4r5idruanKUlJtoxkhuT5EwIIYQQ9xVnVzfbz6kpUnMmhBBCCGFXzi5Xk7P0lGQ7RnJjkpwJIYQQ4r7i7Oxk+zkzLdWOkdyYJGdCCCGEuK8YzQ4opafQSE+R0ZpCCCGEEHZlMABXkjNLRoZ9g7kBSc6EEEIIcR+yAJCZUfBqzhzsHYDIHxaLhczMTHuHIfKB2WzGZCqY68EJIcS9QikLBsCSWfBqziQ5K2SUUsTExBAXF2fvUEQ+8vb2JjAwEIPBYO9QhBDi3qR0zZkls+At3yTJWSGTnZj5+/vj6uoqH96FjFKKlJQUYmNjAQgKCrJzREIIcW9S2cmZRZIzkY8sFostMfP19bV3OCKfuFxZEy42NhZ/f39p4hRCiH8hOzmzysLnIj9l9zFzdXW9TUlxr8v+HUu/QiGE+HeykzNVAGvOJDkrhKQps/CT37EQQvw3VqsVAHXl34JEkjMhhBBC3HeUkuRMiFtSStGvXz+KFCmCwWBg586d9g5JCCFEIWa90qyJJGdC3NiSJUuYPXs2v//+O2fPnqVKlSr2DumOpKWlMWjQIHx9fXF3d6dLly6cO3fO3mEJIYS4Dav1SnKGsmscNyLJmSgQjh49SlBQEA0aNCAwMBAHh+sHEmcUwCU2XnjhBRYuXMj8+fNZs2YNZ86coXPnzvYOSwghxG1kN2uipOZMiOv06tWLIUOGEB0djcFgoGTJkgA8+OCDDB48mGHDhuHn50dERAQAH330EVWrVsXNzY2QkBAGDhxIUlKS7XqzZ8/G29ub33//nQoVKuDq6sqjjz5KSkoKc+bMoWTJkvj4+DB06FAsFovtvPT0dF566SWCg4Nxc3OjXr16rF69+qZxx8fH8+WXX/LRRx/RvHlzwsLCmDVrFhs2bGDTpk358loJIYTIG9kDAgwFr+JM5jkr9JSClBT73NvV9crqsrc2efJkypQpw8yZM9m6dWuOebvmzJnDgAEDWL9+vW2f0WhkypQplCpVimPHjjFw4EBGjhzJ9OnTbWVSUlKYMmUKc+fOJTExkc6dO9OpUye8vb1ZvHgxx44do0uXLjRs2JBu3boBMHjwYPbt28fcuXMpVqwYCxYsoE2bNuzevZty5cpdF3dkZCSZmZm0bNnStq9ixYqEhoayceNG6tev/69eNiGEEPnPeqXGrCCOfZfkrLBLSQF3d/vcOykJ3NxuW8zLywsPDw9MJhOBgYE5jpUrV473338/x75hw4bZfi5ZsiTvvvsu/fv3z5GcZWZmMmPGDMqUKQPAo48+yjfffMO5c+dwd3enUqVKNGvWjFWrVtGtWzeio6OZNWsW0dHRFCtWDICXXnqJJUuWMGvWLMaNG3dd3DExMTg6OuLt7Z1jf0BAADExMbd93kIIIezHVnNWAKvOJDkTBVpYWNh1+5YvX8748eM5cOAACQkJZGVlkZaWRkpKim1yVldXV1tiBjphKlmyJO7XJKoBAQG2ZZB2796NxWKhfPnyOe6Vnp4uqy0IIUQhZLXqpMxQAOvOJDkr7FxddQ2Wve79H7n9o+bt+PHjPPTQQwwYMICxY8dSpEgR1q1bR58+fcjIyLAlZ2azOcd5BoPhhvuyvzklJSVhMpmIjIy8bjkk95vUPAYGBpKRkUFcXFyO2rNz585dVwMohBCiYLFcmUrDWPByM0nOCj2D4Y6aFu8VkZGRWK1WPvzwQ4xGPZ7lxx9//M/XrVmzJhaLhdjYWBo3bnxH54SFhWE2m1mxYgVdunQB4ODBg0RHRxMeHv6fYxJCCJF/rBb95VySMyH+o7Jly5KZmcnUqVPp0KED69ev59NPP/3P1y1fvjw9evTg6aef5sMPP6RmzZqcP3+eFStWUK1aNdq3b3/dOV5eXvTp04fhw4dTpEgRPD09GTJkCOHh4TIYQAghCjiL0s2aRkPBm7ii4EUkxC1Ur16djz76iAkTJlClShW+++47xo8fnyfXnjVrFk8//TQvvvgiFSpUoGPHjmzdupXQ0NCbnjNp0iQeeughunTpQpMmTQgMDOSXX37Jk3iEEELkn+xuLQWx5syglCp4wxTETSUkJODl5UV8fDyenp45jqWlpREVFUWpUqVwdna2U4TibpDftRBC/DfHvplO6dC6RO5bTdiAl/L9frf6/P4nqTkTQgghxH0ne54zYwGsOpPkTAghhBD3HUt2s6ax4KVCBS8iIYQQQoh8lj3PmekOVrK52yQ5E0IIIcR9x3IlOZNmTSGEEEKIAsAqU2kIIYQQQhQc2TVnJqk5E0IIIYSwv+zRmiYZECCEEEIIYX9XKs5ktKYQQgghREGQ3edMas6EuAmlFP369aNIkSIYDAZ27txp75CEEEIUYlJzJsRtLFmyhNmzZ/P7779z9uxZqlSpYu+Q7shzzz1HmTJlcHFxoWjRojzyyCMcOHDAdnzXrl10796dkJAQXFxceOCBB5g8ebIdIxZCCAFXk7OCOM+Zg70DEALg6NGjBAUF0aBBg5uWycjIwNHR8S5GdXthYWH06NGD0NBQLl26xJgxY2jdujVRUVGYTCYiIyPx9/fn22+/JSQkhA0bNtCvXz9MJhODBw+2d/hCCHHfyl5aXGrOhLiBXr16MWTIEKKjozEYDJQsWRKABx98kMGDBzNs2DD8/PyIiIgA4KOPPqJq1aq4ubkREhLCwIEDSUpKsl1v9uzZeHt78/vvv1OhQgVcXV159NFHSUlJYc6cOZQsWRIfHx+GDh2KxWKxnZeens5LL71EcHAwbm5u1KtXj9WrV98y9n79+tGkSRNKlixJrVq1ePfddzl58iTHjx8HoHfv3kyePJmmTZtSunRpnnzySZ555hl++eWXPH0NhRBC5M6VirMCmZxJzVkhp5QiJTPFLvd2NbtiuIPq4smTJ1OmTBlmzpzJ1q1bMZlMtmNz5sxhwIABrF+/3rbPaDQyZcoUSpUqxbFjxxg4cCAjR45k+vTptjIpKSlMmTKFuXPnkpiYSOfOnenUqRPe3t4sXryYY8eO0aVLFxo2bEi3bt0AGDx4MPv27WPu3LkUK1aMBQsW0KZNG3bv3k25cuVu+zySk5OZNWsWpUqVIiQk5Kbl4uPjKVKkyG2vJ4QQIv9Y0Z9PBXESWpQdrVmzRj300EMqKChIAWrBggU5jlutVvXGG2+owMBA5ezsrFq0aKEOHTqUo8zFixfVE088oTw8PJSXl5fq3bu3SkxMzFFm165dqlGjRsrJyUkVL15cTZgw4bpYfvzxR1WhQgXl5OSkqlSpohYtWmS3WG4lPj5eASo+Pv66Y6mpqWrfvn0qNTXVti8pPUkxBrtsSelJd/y8Jk2apEqUKJFjX9OmTVXNmjVve+78+fOVr6+v7fGsWbMUoI4cOWLb99xzzylXV9ccv4+IiAj13HPPKaWUOnHihDKZTOr06dM5rt2iRQs1atSoW95/2rRpys3NTQGqQoUKOe77T+vXr1cODg5q6dKlt31et3Kj37UQQog7t2rqRKVWb1Vxv357V+53q8/vf7JrupicnEz16tWZNm3aDY+///77TJkyhU8//ZTNmzfj5uZGREQEaWlptjI9evRg7969LFu2jN9//521a9fSr18/2/GEhARat25NiRIliIyMZOLEiYwZM4aZM2faymzYsIHu3bvTp08fduzYQceOHenYsSN79uy567GInMLCwq7bt3z5clq0aEFwcDAeHh489dRTXLx4kZSUqzWErq6ulClTxvY4ICCAkiVL4u7unmNfbGwsALt378ZisVC+fHnc3d1t25o1azh69OgtY+zRowc7duxgzZo1lC9fnq5du+b4u8i2Z88eHnnkEUaPHk3r1q1z/VoIIYTIS7rmzCA1ZzfHP2rOrFarCgwMVBMnTrTti4uLU05OTuqHH35QSim1b98+BaitW7fayvzxxx/KYDDYakCmT5+ufHx8VHp6uq3Myy+/rCpUqGB73LVrV9W+ffsc8dSrV89Wq3I3Y7md3NacWa1WlZSeZJfNarXe8fO6Wc3Z888/n2NfVFSUcnJyUsOGDVMbN25UBw8eVF9++aUC1OXLl5VSuubMy8srx3mjR49W1atXz7GvZ8+e6pFHHlFKKTV37lxlMpnUgQMH1OHDh3NsZ8+evePnkZ6erlxdXdX333+fY//evXuVv7+/evXVV+/4WrciNWdCCPHfrJz2oVKrt6rEhfPuyv3umZqzW4mKiiImJoaWLVva9nl5eVGvXj02btwIwMaNG/H29qZ27dq2Mi1btsRoNLJ582ZbmSZNmuQY5RcREcHBgwe5fPmyrcy198kuk32fuxlLXjMYDLg5utllu5P+ZrkVGRmJ1Wrlww8/pH79+pQvX54zZ8785+vWrFkTi8VCbGwsZcuWzbEFBgbe8XWUUiilSE9Pt+3bu3cvzZo1o2fPnowdO/Y/xyqEEOK/y64xkwEBuRATEwPopqdrBQQE2I7FxMTg7++f47iDgwNFihTJUaZUqVLXXSP7mI+PDzExMbe9z92K5Z/S09NzfNAnJCRcV+Z+UrZsWTIzM5k6dSodOnRg/fr1fPrpp//5uuXLl/9/e/ceVVWZ9wH8uzncr0e8cPNyEBAvIKGOCI4K6QiNOqlZji+J+ZrmhQyMMa012ZQKmrAKp7zMmg685htpr03GGLMQhAYjJNLUvOQFpZSLl0FA4uI5z/sHsvMIKAFyNvD9rLVXh2c/e+/f/iHw69n72Rvh4eGIiIhAfHw8/P39ce3aNWRkZGDkyJGYNm1ak20uXryIjz/+GFOnTkXfvn3x008/IS4uDlZWVvj9738PoOFS5uOPP47Q0FCsWrVK/regUqnQt2/fdsdNRERtI6SGyWeSpHpIz86nvHKRDMTGxsLBwUFeHjQLsCfw8/NDQkICNm3aBB8fH+zevRuxsbEdsm+tVouIiAi8/PLL8Pb2xsyZM5Gfn4+BAwc229/S0hL//ve/8fvf/x6enp6YO3cu7Ozs8NVXX8mF+ieffIJr167hww8/hIuLi7z85je/6ZCYiYiobaS7I2ZKnK2pvIjuaryUVFpaatBeWloqr3N2dpZv6G50584d3Lx506BPc/u49xgt9bl3fWfFcr+1a9fi1q1b8vLjjz8226+ri4qKkp8N1igrKwvvvPNOk77R0dG4evUqqqurkZaWhvnz50MIAbVaDaDhuWnl5eUG27zxxhtNXgmVlJSEf/zjH/LXZmZm+Mtf/oLCwkLU1dXh6tWr2LdvH3x9fZuN2dXVFQcOHEBpaSnq6urw448/Yvfu3fD29jY4buOlznuX+8+ViIg6l4kpR85+NXd3dzg7OyMjI0Nuq6ioQF5eHgIDAwEAgYGBKC8vR0FBgdwnMzMTer0eAQEBcp8vv/wS9fX1cp/09HR4e3vLlxEDAwMNjtPYp/E4nRnL/SwsLGBvb2+wEBERUftIJg13dinxnjOjztasrKwUR48eFUePHhUAREJCgjh69Ki4fPmyEEKIuLg4oVarxWeffSaOHz8unnzySeHu7m4wQy0sLEz4+/uLvLw8kZOTI7y8vMS8efPk9eXl5cLJyUnMnz9fnDx5UqSkpAhra2uxY8cOuU/js6e2bNkiTp8+LdatWyfMzMzEiRMn5D6dFcvD/NrZmtQ98XtNRNQ+Obu0QmTlizvpaZ1yvF8zW9OoxdmhQ4cEGt6gYLAsWLBACPHLg1+dnJyEhYWFmDx5sjh79qzBPm7cuCHmzZsnbG1thb29vVi4cOEDH/zq5uYm4uLimsSyZ88eMWTIEGFubi5GjBjR4kNoOyOWB2FxRkLwe01E1F6HUz5sKM4OpnfK8X5NcSYJIURLo2qkPBUVFXBwcMCtW7eaXOKsqalBYWEh3N3dYWlpaaQIqTPwe01E1D5H9u3F2N7u0OsqYfJ4yCM/3oP+ft9PgRdaiYiIiB4tlbkFAE4IICIiIlIEU/mB8CzOiIiIiIzOzNKq4YOkAvR64wZzHxZnRERE1OOYWTUUZ5JkCl1NjZGjMcTijIiIiHocCytr+XNt9W0jRtIUizNSBCEElixZAkdHR0iS1ORp/kRERB3J3NpG/vxz5S0jRtIUizNShLS0NCQlJSE1NRXFxcXw8fExdkitlpubi8cffxw2Njawt7fHxIkT8fPPP8vrNRoNJEkyWOLi4owYMRERWdrZyp9rq39+QM/OZ2rsAIgA4MKFC3BxcUFQUFCLferq6mAuz65RhtzcXISFhWHt2rXYunUrTE1N8d133zV5Hcibb76JxYsXy1/b2dl1dqhERHQPK5t7izNe1qROJARw+7ZxltY+3vi5557Diy++iKKiIkiSBI1GAwAIDg5GZGQkoqKi0KdPH4SGhgIAEhIS4OvrCxsbGwwYMADLly9HVVWVvL+kpCSo1WqkpqbC29sb1tbWmDNnDqqrq5GcnAyNRoNevXph5cqV0Ol08na1tbWIiYmBm5sbbGxsEBAQgKysrAfGHh0djZUrV2LNmjUYMWIEvL298cwzz8DCwsKgn52dHZydneXFxsamhT0SEVFnML/n93QdJwRQZ6quBmxtjbNUV7cuxnfffRdvvvkm+vfvj+LiYuTn58vrkpOTYW5ujsOHD2P79u0AGl5Sm5iYiO+//x7JycnIzMzE6tWr7zvvaiQmJiIlJQVpaWnIysrCrFmzcODAARw4cAC7du3Cjh078Mknn8jbREZGIjc3FykpKTh+/DiefvpphIWF4dy5c83GXVZWhry8PPTr1w9BQUFwcnLCpEmTkJOT06RvXFwcevfuDX9/f7z99tu4c+dO65JDRESPhKQygRD1AIA7P/OyJpEBBwcH2NnZQaVSwdnZ2WCdl5cXNm/ebNAWFRUlf9ZoNFi/fj2WLl2K999/X26vr6/Htm3b4OHhAQCYM2cOdu3ahdLSUtja2mL48OEICQnBoUOHMHfuXBQVFUGr1aKoqAiurq4AgJiYGKSlpUGr1WLjxo1N4r548SIA4I033sCWLVvw2GOP4X/+538wefJknDx5El5eXgCAlStXYtSoUXB0dMRXX32FtWvXori4GAkJCe1PHhERtZ24A0hmqK+rNXYkBlicdXPW1sA9V/w6/djtNXr06CZtBw8eRGxsLM6cOYOKigrcuXMHNTU1qK6uhvXdg1pbW8uFGQA4OTlBo9HA1tbWoK2srAwAcOLECeh0OgwZMsTgWLW1tejdu3ezsenvPrTwhRdewMKFCwEA/v7+yMjIwAcffIDY2FgAwKpVq+RtRo4cCXNzc7zwwguIjY1tcvmTiIg6kWi4teVOXZ2RAzHE4qybkySgK9/edP+9WZcuXcL06dOxbNkybNiwAY6OjsjJycGiRYtQV1cnF2dmZmYG20mS1GxbY4FVVVUFlUqFgoICqFSGr/K4t6C7l4uLCwBg+PDhBu3Dhg1DUVFRi+cUEBCAO3fu4NKlS/D29m6xHxERPVpC6CCBxRlRuxQUFECv1yM+Pl6eEblnz55279ff3x86nQ5lZWWYMGFCq7bRaDRwdXXF2bNnDdp/+OEHPPHEEy1ud+zYMZiYmKBfv37tipmIiNpHoGHkTNypN3IkhlicUZfi6emJ+vp6bN26FTNmzDCYKNAeQ4YMQXh4OCIiIhAfHw9/f39cu3YNGRkZGDlyJKZNm9ZkG0mS8Kc//Qnr1q2Dn58fHnvsMSQnJ+PMmTPyRIPc3Fzk5eUhJCQEdnZ2yM3NRXR0NJ599ln06tWr3XETEVHbibuXNXUKm6TF4oy6FD8/PyQkJGDTpk1Yu3YtJk6ciNjYWERERLR731qtFuvXr8fLL7+MK1euoE+fPhg3bhymT5/e4jZRUVGoqalBdHQ0bt68CT8/P6Snp8v3u1lYWCAlJQVvvPEGamtr4e7ujujoaIP70IiIyDiEvqE40+uUNXImCdHap1GRElRUVMDBwQG3bt2Cvb29wbqamhoUFhbC3d0dlpaWRoqQOgO/10RE7Vf3r/0wt3RF9tmvMWlJ5CM91oP+ft+PzzkjIiKiHqnxsqZer3tIz87F4oyIiIh6JL1omLEPnd64gdyHxRkRERH1SI33nEGwOCMiIiIyOnnkTGG337M4IyIioh6p8UHkEkfOiIiIiIxPHjkDR86IiIiIjE4eOTNyHPdjcUZEREQ9EoszogcQQmDJkiVwdHSEJEk4duyYsUMiIqJuTnf3sqaJwqozFmekCGlpaUhKSkJqaiqKi4vh4+Nj7JBa5cKFC5g1axb69u0Le3t7PPPMMygtLZXXZ2VlQZKkZpf8/HwjRk5ERI0jZ0orhpQWD/VQFy5cgIuLC4KCguDs7AxT06avfa2rqzNCZC27ffs2pk6dCkmSkJmZicOHD6Ourg4zZsyQf+CDgoJQXFxssDz//PNwd3fHmDFjjHwGREQ9m67xsqakrKEzFmdkdM899xxefPFFFBUVQZIkaDQaAEBwcDAiIyMRFRWFPn36IDQ0FACQkJAAX19f2NjYYMCAAVi+fDmqqqrk/SUlJUGtViM1NRXe3t6wtrbGnDlzUF1djeTkZGg0GvTq1QsrV66ETvfLKztqa2sRExMDNzc32NjYICAgAFlZWS3GffjwYVy6dAlJSUnw9fWFr68vkpOT8c033yAzMxMAYG5uDmdnZ3np3bs3PvvsMyxcuFBxvwyIiHoa0ThyprDfx02HJ6h7EQLQVRvn2CproBX/4N999114eHhg586dyM/Ph0qlktclJydj2bJlOHz4sNxmYmKCxMREuLu74+LFi1i+fDlWr16N999/X+5TXV2NxMREpKSkoLKyErNnz8asWbOgVqtx4MABXLx4EU899RTGjx+PuXPnAgAiIyNx6tQppKSkwNXVFZ9++inCwsJw4sQJeHl5NYm7trYWkiTBwsJCbrO0tISJiQlycnIwZcqUJtvs378fN27cwMKFC1uXQyIiemR0+oZHaKgUNlTF4qy701UDe2yNc+xnqgBTm4d2c3BwgJ2dHVQqFZydnQ3WeXl5YfPmzQZtUVFR8meNRoP169dj6dKlBsVZfX09tm3bBg8PDwDAnDlzsGvXLpSWlsLW1hbDhw9HSEgIDh06hLlz56KoqAharRZFRUVwdXUFAMTExCAtLQ1arRYbN25sEve4ceNgY2ODV155BRs3boQQAmvWrIFOp0NxcXGz5/r3v/8doaGh6N+//0PzQkREj1bjhABJUlZ1pqxoiO4zevToJm0HDx7E5MmT4ebmBjs7O8yfPx83btxAdfUvI4TW1tZyYQYATk5O0Gg0sLW1NWgrKysDAJw4cQI6nQ5DhgyBra2tvGRnZ+PChQvNxta3b1/s3bsXn3/+OWxtbeHg4IDy8nKMGjUKJiZNf7R++ukn/Otf/8KiRYvanA8iIuo4+rsjZ7ysSZ1LZd0wgmWsY7eTjY3hyNulS5cwffp0LFu2DBs2bICjoyNycnKwaNEi1NXVwdq64ZhmZmYG20mS1Gxb4437VVVVUKlUKCgoMLisCsCgoLvf1KlTceHCBVy/fh2mpqZQq9VwdnbG4MGDm/TVarXo3bs3/vCHP7Q+AURE9Mg0TghQKexZGizOujtJatWlxa6ioKAAer0e8fHx8ujUnj172r1ff39/6HQ6lJWVYcKECb96+z59+gAAMjMzUVZW1qQAE0JAq9UiIiKiSZFIRETG8cs9Z8q6kMjijLoUT09P1NfXY+vWrZgxYwYOHz6M7du3t3u/Q4YMQXh4OCIiIhAfHw9/f39cu3YNGRkZGDlyJKZNm9bsdlqtFsOGDUPfvn2Rm5uLl156CdHR0fD29jbol5mZicLCQjz//PPtjpWIiDpG47s1FVab8Z4z6lr8/PyQkJCATZs2wcfHB7t370ZsbGyH7LtxZOvll1+Gt7c3Zs6cifz8fAwcOLDFbc6ePYuZM2di2LBhePPNN/Haa69hy5YtTfr9/e9/R1BQEIYOHdohsRIRUfvp5ZEz1UN6di5JCKGsV7HTA1VUVMDBwQG3bt2Cvb29wbqamhoUFhbC3d0dlpaWRoqQOgO/10RE7fftjniMGjoJ5y9/Dc+IyEd6rAf9/b4fR86IiIioR1LqyBmLMyIiIuqR7tZmMFHYbE0WZ0RERNQjNU4IUPEhtERERETG98vImbLKIWVFQ0RERNRJBC9rEhERESmH/u5/lfYQWmVFQ0RERNRJGp8lZsLZmkRERETGJxdnnBBAREREZHwCDfeacUIAUTOEEFiyZAkcHR0hSRKOHTtm7JCIiKjbu1ucceSMqKm0tDQkJSUhNTUVxcXF8PHxMXZIrbJz504EBwfD3t4ekiShvLzcYP2lS5ewaNEiuLu7w8rKCh4eHli3bh3q6uoM+u3ZswePPfYYrK2tMWjQILz99tudeBZERD3U3aJMaSNnpsYOgAgALly4ABcXFwQFBbXYp66uDubm5p0Y1cNVV1cjLCwMYWFhWLt2bZP1Z86cgV6vx44dO+Dp6YmTJ09i8eLFuH37tvyC9C+++ALh4eHYunUrpk6ditOnT2Px4sWwsrJCZOSjfdcbEVFPJkwaR844IYDIwHPPPYcXX3wRRUVFkCQJGo0GABAcHIzIyEhERUWhT58+CA0NBQAkJCTA19cXNjY2GDBgAJYvX46qqip5f0lJSVCr1UhNTYW3tzesra0xZ84cVFdXIzk5GRqNBr169cLKlSuh0+nk7WpraxETEwM3NzfY2NggICAAWVlZD4w9KioKa9aswbhx45pdHxYWBq1Wi6lTp2Lw4MH4wx/+gJiYGOzbt0/us2vXLsycORNLly7F4MGDMW3aNKxduxabNm2CaHwIDxERdTjpblEmKeyyJkfOujshAL3+4f0eBRMTQHr4g/3effddeHh4YOfOncjPz4dK9cv/wSQnJ2PZsmU4fPjwPbs1QWJiItzd3XHx4kUsX74cq1evxvvvvy/3qa6uRmJiIlJSUlBZWYnZs2dj1qxZUKvVOHDgAC5evIinnnoK48ePx9y5cwEAkZGROHXqFFJSUuDq6opPP/0UYWFhOHHiBLy8vDosLbdu3YKjo6P8dW1tLaytrQ36WFlZ4aeffsLly5flYpWIiDqWpGq8rKmskTMWZ92dXg/kHDXOsX/rD6ge/g/ewcEBdnZ2UKlUcHZ2Nljn5eWFzZs3G7RFRUXJnzUaDdavX4+lS5caFGf19fXYtm0bPDw8AABz5szBrl27UFpaCltbWwwfPhwhISE4dOgQ5s6di6KiImi1WhQVFcHV1RUAEBMTg7S0NGi1WmzcuLGtWTBw/vx5bN26Vb6kCQChoaGIjo7Gc889h5CQEJw/fx7x8fEAgOLiYhZnRESPikqZI2fKiqYHee+996DRaGBpaYmAgAAcOXLE2CEp0ujRo5u0HTx4EJMnT4abmxvs7Owwf/583LhxA9XV1XIfa2truTADACcnJ2g0Gtja2hq0lZWVAQBOnDgBnU6HIUOGwNbWVl6ys7Nx4cKFDjmXK1euICwsDE8//TQWL14sty9evBiRkZGYPn06zM3NMW7cOPzxj38EoLybVImIuhMTuTjjyFmP9/HHH2PVqlXYvn07AgIC8M477yA0NBRnz55Fv379OvZgJiYNI1jG0AGFhY2NjcHXly5dwvTp07Fs2TJs2LABjo6OyMnJwaJFi1BXVydfHjQzMzPYTpKkZtv0dy/5VlVVQaVSoaCgwOCyKgCDgq6trl69ipCQEAQFBWHnzp1N4ti0aRM2btyIkpIS9O3bFxkZGQCAwYMHt/vYRETUPJWqYZKZ0kbOWJwZQUJCAhYvXoyFCxcCALZv345//vOf+OCDD7BmzZqOPZgkterSYldRUFAAvV6P+Ph4eVRpz5497d6vv78/dDodysrKMGHChHbv715XrlxBSEgIRo8eDa1W2+JomEqlgpubGwDgo48+QmBgIPr27duhsRAR0S9Ud/+nXTIxw/F/HTBoH/H474wVFouzzlZXV4eCggKDxy6YmJhgypQpyM3NbdK/trYWtbW18tcVFRWdEqdSeXp6or6+Hlu3bsWMGTNw+PBhbN++vd37HTJkCMLDwxEREYH4+Hj4+/vj2rVryMjIwMiRIzFt2rRmtyspKUFJSQnOnz8PoOHyqJ2dHQYOHAhHR0dcuXIFwcHBGDRoELZs2YJr167J2zbeX3f9+nV88sknCA4ORk1NDbRaLfbu3Yvs7Ox2nxcREbXMxLyhODNR2WOkyl5u19XfMFZIAHjPWae7fv06dDodnJycDNqdnJxQUlLSpH9sbCwcHBzkZcCAAZ0VqiL5+fkhISEBmzZtgo+PD3bv3o3Y2NgO2bdWq0VERARefvlleHt7Y+bMmcjPz8fAgQNb3Gb79u3w9/eX7yGbOHEi/P39sX//fgBAeno6zp8/j4yMDPTv3x8uLi7ycq/k5GSMGTMG48ePx/fff4+srCyMHTu2Q86LiIia5/u7J1BZcQ5CX2uw6PX1Ro1LEnyQUqe6evUq3Nzc8NVXXyEwMFBuX716NbKzs5GXl2fQv7mRswEDBuDWrVuwt7c36FtTU4PCwkK4u7vD0tLy0Z4IGRW/10REXUtFRQUcHBya/ft9P17W7GR9+vSBSqVCaWmpQXtpaWmTx0gAgIWFBSwsLDorPCIiIjIyXtbsZObm5hg9erQ8Gw8A9Ho9MjIyDEbSiIiIqGfiyJkRrFq1CgsWLMCYMWMwduxYvPPOO7h9+7Y8e5OIiIh6LhZnRjB37lxcu3YNr7/+OkpKSvDYY48hLS2tySQBIiIi6nlYnBlJZGQkIiMjjR0GERERKQzvOeuGOAG3++P3mIio+2Jx1o00vp7o3ndMUvfU+D2+/5VURETU9fGyZjeiUqmgVqvll3lbW1tDkiQjR0UdSQiB6upqlJWVQa1WN3kPKBERdX0szrqZxmelNRZo1D2p1epmn4tHRERdH4uzbkaSJLi4uKBfv36orzfu6yfo0TAzM+OIGRFRN8birJtSqVT8A05ERNQFcUIAERERkYKwOCMiIiJSEBZnRERERArCe866mMaHj1ZUVBg5EiIiImqtxr/brXmIOIuzLqayshIAMGDAACNHQkRERL9WZWUlHBwcHthHEnwPTJei1+tx9epV2NnZdfgDZisqKjBgwAD8+OOPsLe379B9d3fMXdsxd23H3LUdc9d2zF3bCCFQWVkJV1dXmJg8+K4yjpx1MSYmJujfv/8jPYa9vT1/4NqIuWs75q7tmLu2Y+7ajrn79R42YtaIEwKIiIiIFITFGREREZGCsDgjmYWFBdatWwcLCwtjh9LlMHdtx9y1HXPXdsxd2zF3jx4nBBAREREpCEfOiIiIiBSExRkRERGRgrA4IyIiIlIQFmdERERECsLijAAA7733HjQaDSwtLREQEIAjR44YOyTFiY2NxW9+8xvY2dmhX79+mDlzJs6ePWvQp6amBitWrEDv3r1ha2uLp556CqWlpUaKWLni4uIgSRKioqLkNuauZVeuXMGzzz6L3r17w8rKCr6+vvjmm2/k9UIIvP7663BxcYGVlRWmTJmCc+fOGTFi5dDpdPjzn/8Md3d3WFlZwcPDA2+99ZbB+w2ZvwZffvklZsyYAVdXV0iShH/84x8G61uTp5s3byI8PBz29vZQq9VYtGgRqqqqOvEsugcWZ4SPP/4Yq1atwrp16/Dtt9/Cz88PoaGhKCsrM3ZoipKdnY0VK1bg66+/Rnp6Ourr6zF16lTcvn1b7hMdHY3PP/8ce/fuRXZ2Nq5evYrZs2cbMWrlyc/Px44dOzBy5EiDduauef/5z38wfvx4mJmZ4YsvvsCpU6cQHx+PXr16yX02b96MxMREbN++HXl5ebCxsUFoaChqamqMGLkybNq0Cdu2bcNf//pXnD59Gps2bcLmzZuxdetWuQ/z1+D27dvw8/PDe++91+z61uQpPDwc33//PdLT05Gamoovv/wSS5Ys6axT6D4E9Xhjx44VK1askL/W6XTC1dVVxMbGGjEq5SsrKxMARHZ2thBCiPLycmFmZib27t0r9zl9+rQAIHJzc40VpqJUVlYKLy8vkZ6eLiZNmiReeuklIQRz9yCvvPKK+O1vf9vier1eL5ydncXbb78tt5WXlwsLCwvx0UcfdUaIijZt2jTx3//93wZts2fPFuHh4UII5q8lAMSnn34qf92aPJ06dUoAEPn5+XKfL774QkiSJK5cudJpsXcHHDnr4erq6lBQUIApU6bIbSYmJpgyZQpyc3ONGJny3bp1CwDg6OgIACgoKEB9fb1BLocOHYqBAwcyl3etWLEC06ZNM8gRwNw9yP79+zFmzBg8/fTT6NevH/z9/fG3v/1NXl9YWIiSkhKD3Dk4OCAgIKDH5w4AgoKCkJGRgR9++AEA8N133yEnJwdPPPEEAOavtVqTp9zcXKjVaowZM0buM2XKFJiYmCAvL6/TY+7K+OLzHu769evQ6XRwcnIyaHdycsKZM2eMFJXy6fV6REVFYfz48fDx8QEAlJSUwNzcHGq12qCvk5MTSkpKjBClsqSkpODbb79Ffn5+k3XMXcsuXryIbdu2YdWqVXj11VeRn5+PlStXwtzcHAsWLJDz09zPcE/PHQCsWbMGFRUVGDp0KFQqFXQ6HTZs2IDw8HAAYP5aqTV5KikpQb9+/QzWm5qawtHRkbn8lVicEbXBihUrcPLkSeTk5Bg7lC7hxx9/xEsvvYT09HRYWloaO5wuRa/XY8yYMdi4cSMAwN/fHydPnsT27duxYMECI0enfHv27MHu3bvxv//7vxgxYgSOHTuGqKgouLq6Mn+kWLys2cP16dMHKpWqyay40tJSODs7GykqZYuMjERqaioOHTqE/v37y+3Ozs6oq6tDeXm5QX/msuGyZVlZGUaNGgVTU1OYmpoiOzsbiYmJMDU1hZOTE3PXAhcXFwwfPtygbdiwYSgqKgIAOT/8GW7en/70J6xZswZ//OMf4evri/nz5yM6OhqxsbEAmL/Wak2enJ2dm0wku3PnDm7evMlc/koszno4c3NzjB49GhkZGXKbXq9HRkYGAgMDjRiZ8gghEBkZiU8//RSZmZlwd3c3WD969GiYmZkZ5PLs2bMoKirq8bmcPHkyTpw4gWPHjsnLmDFjEB4eLn9m7po3fvz4Jo9s+eGHHzBo0CAAgLu7O5ydnQ1yV1FRgby8vB6fOwCorq6GiYnhnzqVSgW9Xg+A+Wut1uQpMDAQ5eXlKCgokPtkZmZCr9cjICCg02Pu0ow9I4GMLyUlRVhYWIikpCRx6tQpsWTJEqFWq0VJSYmxQ1OUZcuWCQcHB5GVlSWKi4vlpbq6Wu6zdOlSMXDgQJGZmSm++eYbERgYKAIDA40YtXLdO1tTCOauJUeOHBGmpqZiw4YN4ty5c2L37t3C2tpafPjhh3KfuLg4oVarxWeffSaOHz8unnzySeHu7i5+/vlnI0auDAsWLBBubm4iNTVVFBYWin379ok+ffqI1atXy32YvwaVlZXi6NGj4ujRowKASEhIEEePHhWXL18WQrQuT2FhYcLf31/k5eWJnJwc4eXlJebNm2esU+qyWJyREEKIrVu3ioEDBwpzc3MxduxY8fXXXxs7JMUB0Oyi1WrlPj///LNYvny56NWrl7C2thazZs0SxcXFxgtawe4vzpi7ln3++efCx8dHWFhYiKFDh4qdO3carNfr9eLPf/6zcHJyEhYWFmLy5Mni7NmzRopWWSoqKsRLL70kBg4cKCwtLcXgwYPFa6+9Jmpra+U+zF+DQ4cONfs7bsGCBUKI1uXpxo0bYt68ecLW1lbY29uLhQsXisrKSiOcTdcmCXHPY5KJiIiIyKh4zxkRERGRgrA4IyIiIlIQFmdERERECsLijIiIiEhBWJwRERERKQiLMyIiIiIFYXFGREREpCAszoiIFCQ4OBhRUVHy1xqNBu+8847R4iGizsfijIioDbKysiBJUotLSEhIhxwnPz8fS5Ys6ZB9EVHXYGrsAIiIuqKgoCAUFxc3ad+/fz+WLl2K5cuXd8hx+vbt2yH7IaKugyNnRERtYG5uDmdnZ4PlP//5D2JiYvDqq6/i6aefbnHb999/H15eXrC0tISTkxPmzJnTYt/7L2uWl5fjhRdegJOTEywtLeHj44PU1FR5fU5ODiZMmAArKysMGDAAK1euxO3btzvknImoc3DkjIioA5SXl+PJJ59EcHAw3nrrrRb7ffPNN1i5ciV27dqFoKAg3Lx5E//+979bdQy9Xo8nnngClZWV+PDDD+Hh4YFTp05BpVIBAC5cuICwsDCsX78eH3zwAa5du4bIyEhERkZCq9V2yHkS0aPH4oyIqJ30ej3+67/+C6ampti9ezckSWqxb1FREWxsbDB9+nTY2dlh0KBB8Pf3b9VxDh48iCNHjuD06dMYMmQIAGDw4MHy+tjYWISHh8sTCry8vJCYmIhJkyZh27ZtsLS0bPtJElGnYXFGRNROr776KnJzc3HkyBHY2dk9sO/vfvc7DBo0CIMHD0ZYWBjCwsIwa9YsWFtbP/Q4x44dQ//+/eXC7H7fffcdjh8/jt27d8ttQgjo9XoUFhZi2LBhv+7EiMgoeM8ZEVE7pKSkYMuWLUhJSYGXl9dD+9vZ2eHbb7/FRx99BBcXF7z++uvw8/NDeXn5Q7e1srJ64Pqqqiq88MILOHbsmLx89913OHfuHDw8PFp7SkRkZBw5IyJqo2PHjmHRokWIi4tDaGhoq7czNTXFlClTMGXKFKxbtw5qtRqZmZmYPXv2A7cbOXIkfvrpJ/zwww/Njp6NGjUKp06dgqen568+FyJSDhZnRERtcP36dcycORPBwcF49tlnUVJSYrBepVI1+xiM1NRUXLx4ERMnTkSvXr1w4MAB6PV6eHt7P/SYkyZNwsSJE/HUU08hISEBnp6eOHPmDCRJQlhYGF555RWMGzcOkZGReP7552FjY4NTp04hPT0df/3rXzvs3Ino0WJxRkTUBv/85z9x+fJlXL58GS4uLk3WDxo0CJcuXWrSrlarsW/fPrzxxhuoqamBl5cXPvroI4wYMaJVx/2///s/xMTEYN68ebh9+zY8PT0RFxcHoGFkLTs7G6+99homTJgAIQQ8PDwwd+7cdp0rEXUuSQghjB0EERERETXghAAiIiIiBWFxRkRERKQgLM6IiIiIFITFGREREZGCsDgjIiIiUhAWZ0REREQKwuKMiIiISEFYnBEREREpCIszIiIiIgVhcUZERESkICzOiIiIiBSExRkRERGRgvw/mYRrkt/OqSMAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 640x480 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#channel is hard coded in the function right now. Need to allow it to be passed as a parameter by the user \n",
     "if membrane_regions_exist == True:      \n",
-    "    plot_z_sum_bd(z2)"
+    "    boundaries = plot_z_sum_bd(z2)"
    ]
   },
   {
@@ -380,13 +353,40 @@
    "id": "ecb379ec",
    "metadata": {},
    "source": [
-    "This Z axis plot shows where the max intensities are, which roughly correspond to the basal and apical regions of the cell. \n",
-    "Use this plot and scan through the z series in Napari below to determine the cutoff Z slice values for basal, lateral, and apical regions of the cell"
+    "This Z axis plot shows where the max intensities are, which roughly correspond to the basal and apical regions of the cell.\n",
+    "\n",
+    "The lines are the auto-detected boundaries between basal, lateral, and apical.  \n",
+    "\n",
+    "If needed, you can scan through the z series in Napari below to adjust the position of these boundaries."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
+   "id": "ac8b9927",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# If ychange the values of the boundaries to the ones you want to use\n",
+    "\n",
+    "basal_lateral_boundary_slice_manual = []\n",
+    "lateral_apical_boundary_slice_manual = []\n",
+    "\n",
+    "if membrane_regions_exist == True and basal_lateral_boundary_slice_manual:\n",
+    "    boundaries = [basal_lateral_boundary_slice_manual, lateral_apical_boundary_slice_manual]\n",
+    "    print('Manual basal-lateral boundary slice is:', basal_lateral_boundary_slice_manual)   \n",
+    "    print('Manual lateral-apical boundary slice is:', lateral_apical_boundary_slice_manual)\n",
+    "\n",
+    "else:\n",
+    "    print('Basal-lateral boundary slice is:', boundaries[0])   \n",
+    "    print('Lateral-apical boundary slice is:', boundaries[1])  \n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "2b5a1073",
    "metadata": {},
    "outputs": [],
@@ -411,45 +411,7 @@
    "execution_count": null,
    "id": "ddd3f511",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Traceback (most recent call last):\n",
-      "  File \"/Users/makamats/opt/anaconda3/envs/cme_pipeline/lib/python3.10/site-packages/napari/_qt/qt_main_window.py\", line 572, in closeEvent\n",
-      "    quit_app()\n",
-      "  File \"/Users/makamats/opt/anaconda3/envs/cme_pipeline/lib/python3.10/site-packages/napari/_qt/qt_event_loop.py\", line 232, in quit_app\n",
-      "    v.close()\n",
-      "  File \"/Users/makamats/opt/anaconda3/envs/cme_pipeline/lib/python3.10/site-packages/napari/viewer.py\", line 146, in close\n",
-      "    self.window.close()\n",
-      "  File \"/Users/makamats/opt/anaconda3/envs/cme_pipeline/lib/python3.10/site-packages/napari/_qt/qt_main_window.py\", line 1525, in close\n",
-      "    self._qt_viewer.close()\n",
-      "RuntimeError: wrapped C/C++ object of type QtViewer has been deleted\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/Users/makamats/opt/anaconda3/envs/cme_pipeline/lib/python3.10/site-packages/napari/_qt/qt_main_window.py\", line 572, in closeEvent\n",
-      "    quit_app()\n",
-      "  File \"/Users/makamats/opt/anaconda3/envs/cme_pipeline/lib/python3.10/site-packages/napari/_qt/qt_event_loop.py\", line 232, in quit_app\n",
-      "    v.close()\n",
-      "  File \"/Users/makamats/opt/anaconda3/envs/cme_pipeline/lib/python3.10/site-packages/napari/viewer.py\", line 146, in close\n",
-      "    self.window.close()\n",
-      "  File \"/Users/makamats/opt/anaconda3/envs/cme_pipeline/lib/python3.10/site-packages/napari/_qt/qt_main_window.py\", line 1525, in close\n",
-      "    self._qt_viewer.close()\n",
-      "RuntimeError: wrapped C/C++ object of type QtViewer has been deleted\n"
-     ]
-    },
-    {
-     "ename": "",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31mThe Kernel crashed while executing code in the current cell or a previous cell. \n",
-      "\u001b[1;31mPlease review the code in the cell(s) to identify a possible cause of the failure. \n",
-      "\u001b[1;31mClick <a href='https://aka.ms/vscodeJupyterKernelCrash'>here</a> for more info. \n",
-      "\u001b[1;31mView Jupyter <a href='command:jupyter.viewOutput'>log</a> for further details."
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "final_tracks.to_pickle(output_directory_full)"
    ]
@@ -464,21 +426,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "62719e16-1dac-4db9-96b1-8d9362589127",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Tracks layer 'all tracks' at 0x26ce5b970>"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Create a napari viewer\n",
     "viewer = napari.Viewer()\n",
@@ -490,37 +441,43 @@
     "#for the sake of improved performance only 1 channel could be imported here (if images get super large and performance issues occur)\n",
     "all_channels = dask_array[:,:,:,:,:]\n",
     "\n",
+    "# # Calculate the 1st and 99th percentiles for the 10th time point\n",
+    "# lower_limit_1, upper_limit_1 = da.percentile(all_channels[10,0,:,:,:].ravel(), [5, 95]).compute()\n",
+    "# lower_limit_2, upper_limit_2 = da.percentile(all_channels[10,1,:,:,:].ravel(), [5, 95]).compute()\n",
+    "# lower_limit_3, upper_limit_3 = da.percentile(all_channels[10,2,:,:,:].ravel(), [5, 95]).compute()\n",
+    "\n",
+    "\n",
+    "# # Set the contrast limits\n",
+    "\n",
+    "# # Add each channel as a separate image layer with its own contrast limits\n",
+    "# layer_raw_1 = viewer.add_image(all_channels[0], contrast_limits=[lower_limit_1, upper_limit_1], name='channel 1', colormap='yellow')\n",
+    "# layer_raw_2 = viewer.add_image(all_channels[1], contrast_limits=[lower_limit_2, upper_limit_2], name='channel 2', colormap = 'cyan')\n",
+    "# layer_raw_3 = viewer.add_image(all_channels[2], contrast_limits=[lower_limit_3, upper_limit_3], name='channel 3', colormap = 'magenta')\n",
+    "\n",
     "# Add the 4D stack to the viewer\n",
     "layer_raw = viewer.add_image(all_channels, channel_axis = 1, name = ['channel 1', 'channel 2', 'channel 3'])\n",
     "#other useful parameters \n",
     "#color_map = list\n",
     "#contrast_limits = list of list \n",
     "\n",
+    "track_properties = {'number_of_frames': track_df['number_of_frames'].to_numpy(), 'track_id_rand': track_df['color'].to_numpy()}\n",
+    "\n",
+    "# viewer.add_tracks(track_df[[\"track_id\", \"frame\", \"c3_peak_z\", \"c3_peak_y\", \"c3_peak_x\"]], name = 'all tracks')\n",
+    "\n",
+    "tracks_layer = viewer.add_tracks(track_df[[\"track_id\", \"frame\", \"c3_peak_z\", \"c3_peak_y\", \"c3_peak_x\"]], name = 'all tracks', properties=track_properties, color_by='track_id_rand', tail_length = 15, tail_width = 2, colormap = 'hsv')\n",
+    "\n",
     "# Add Bounding Box\n",
     "layer_raw[0].bounding_box.visible = True\n",
     "layer_raw[1].bounding_box.visible = True\n",
-    "layer_raw[2].bounding_box.visible = True\n",
-    "\n",
-    "viewer.add_tracks(track_df[[\"track_id\", \"frame\", \"c3_peak_z\", \"c3_peak_y\", \"c3_peak_x\"]], name = 'all tracks')"
+    "layer_raw[2].bounding_box.visible = True\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "0ec6dd6b-eeab-47c6-b427-5881a95b43ad",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Tracks layer 'channel2+ tracks' at 0x29d40ceb0>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#Displaying Dynamin Positive tracks only (Tracks where actin is not present)\n",
     "dnm2_positive_tracks_df = final_tracks[(final_tracks['channel2_positive'] == True) & (final_tracks['channel1_positive'] == False)]\n",
@@ -531,21 +488,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "41bb1f4a-bec4-4c77-bf42-7e0d94f1e036",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Tracks layer 'channel1+ tracks' at 0x2a0b2de40>"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#Displaying Actin Positive tracks only (Tracks where Dynamin is not present)\n",
     "actin_positive_tracks_df = final_tracks[(final_tracks['channel2_positive'] == False) & (final_tracks['channel1_positive'] == True)]\n",
@@ -556,21 +502,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "b6aa5ee9-e2e2-4991-a44f-51b0aff593b5",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Tracks layer 'all+ tracks' at 0x29df23fd0>"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#Displaying all 3 channels positive tracks \n",
     "all_positive_tracks_df = final_tracks[(final_tracks['channel2_positive'] == True) & (final_tracks['channel1_positive'] == True)]\n",
@@ -581,7 +516,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "id": "4ea2b818-5720-4fd5-9c89-00e029243988",
    "metadata": {},
    "outputs": [],
@@ -596,7 +531,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "id": "44aae7c0-40b0-4914-a762-9b27bfd39af5",
    "metadata": {},
    "outputs": [],
@@ -611,35 +546,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "id": "76d99053-b93e-470a-8749-b4684bd40c51",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/makamats/opt/anaconda3/envs/cme_pipeline/lib/python3.10/site-packages/napari/_vispy/layers/image.py:251: UserWarning: data shape (115, 2052, 340) exceeds GL_MAX_TEXTURE_SIZE 2048 in at least one axis and will be downsampled. Rendering is currently in 3D mode.\n",
-      "  warnings.warn(\n",
-      "/Users/makamats/opt/anaconda3/envs/cme_pipeline/lib/python3.10/site-packages/napari/_vispy/layers/image.py:251: UserWarning: data shape (115, 2052, 340) exceeds GL_MAX_TEXTURE_SIZE 2048 in at least one axis and will be downsampled. Rendering is currently in 3D mode.\n",
-      "  warnings.warn(\n",
-      "/Users/makamats/opt/anaconda3/envs/cme_pipeline/lib/python3.10/site-packages/napari/_vispy/layers/image.py:251: UserWarning: data shape (115, 2052, 340) exceeds GL_MAX_TEXTURE_SIZE 2048 in at least one axis and will be downsampled. Rendering is currently in 3D mode.\n",
-      "  warnings.warn(\n",
-      "/Users/makamats/opt/anaconda3/envs/cme_pipeline/lib/python3.10/site-packages/napari/_vispy/layers/image.py:251: UserWarning: data shape (115, 2052, 340) exceeds GL_MAX_TEXTURE_SIZE 2048 in at least one axis and will be downsampled. Rendering is currently in 3D mode.\n",
-      "  warnings.warn(\n",
-      "/Users/makamats/opt/anaconda3/envs/cme_pipeline/lib/python3.10/site-packages/napari/_vispy/layers/image.py:251: UserWarning: data shape (115, 2052, 340) exceeds GL_MAX_TEXTURE_SIZE 2048 in at least one axis and will be downsampled. Rendering is currently in 3D mode.\n",
-      "  warnings.warn(\n",
-      "/Users/makamats/opt/anaconda3/envs/cme_pipeline/lib/python3.10/site-packages/napari/_vispy/layers/image.py:251: UserWarning: data shape (115, 2052, 340) exceeds GL_MAX_TEXTURE_SIZE 2048 in at least one axis and will be downsampled. Rendering is currently in 3D mode.\n",
-      "  warnings.warn(\n",
-      "/Users/makamats/opt/anaconda3/envs/cme_pipeline/lib/python3.10/site-packages/napari/_vispy/layers/image.py:251: UserWarning: data shape (115, 2052, 340) exceeds GL_MAX_TEXTURE_SIZE 2048 in at least one axis and will be downsampled. Rendering is currently in 3D mode.\n",
-      "  warnings.warn(\n",
-      "/Users/makamats/opt/anaconda3/envs/cme_pipeline/lib/python3.10/site-packages/napari/_vispy/layers/image.py:251: UserWarning: data shape (115, 2052, 340) exceeds GL_MAX_TEXTURE_SIZE 2048 in at least one axis and will be downsampled. Rendering is currently in 3D mode.\n",
-      "  warnings.warn(\n",
-      "/Users/makamats/opt/anaconda3/envs/cme_pipeline/lib/python3.10/site-packages/napari/_vispy/layers/image.py:251: UserWarning: data shape (115, 2052, 340) exceeds GL_MAX_TEXTURE_SIZE 2048 in at least one axis and will be downsampled. Rendering is currently in 3D mode.\n",
-      "  warnings.warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#Displaying apical tracks \n",
     "if membrane_regions_exist == True:\n",
@@ -654,7 +564,7 @@
    "id": "cb27befc-b298-4b91-9feb-49b84a9d852e",
    "metadata": {},
    "source": [
-    "### final_tracks dataframe stores tracks which are at least clathrin positive."
+    "### final_tracks dataframe stores tracks which are at least positive in the channel you tracked."
    ]
   },
   {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/880c7d80-9af2-4ed5-9985-258a8b384e31)

    auto-detected basal and apical boundaries by smoothing, detecting 2 peaks, and offsetting by 6 slices

 smooth all_slices_mean with a kernel of size 4
    all_slices_mean_smooth = np.convolve(all_slices_mean, np.ones(4), mode='same')

    region_boundaries = find_top_n_peaks(all_slices_mean_smooth, 2)

    offset the region boundaries by 6 slices so that basal and apical regions are more fully captured
    region_boundary_offset = 6